### PR TITLE
Develop b

### DIFF
--- a/alembic/versions/0008_metric_fits.py
+++ b/alembic/versions/0008_metric_fits.py
@@ -1,0 +1,60 @@
+"""metric_fits table — Riemannian metric fit registry
+
+Revision ID: 0008_metric_fits
+Revises: 0007_recovery_runs
+Create Date: 2026-05-01 00:00:00
+
+Phase 5's storage substrate for the Riemannian metric learner. Each
+row is one trained metric: a pointer to the on-disk `.npz` artefact
+plus enough provenance (policy_id, n_anchors, n_jacobians, val_loss,
+hyperparams) for downstream commands to pick the right metric without
+re-fitting. Issue #50 spec called this `0012_metric_fits` assuming
+intermediate Phase-5 issues would land first; we file under the next
+free slot so the chain stays linear.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_metric_fits"
+down_revision: str | None = "0007_recovery_runs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "metric_fits",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("policy_id", sa.String(length=64), nullable=False),
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column(
+            "trained_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+        sa.Column("n_anchors", sa.Integer(), nullable=False),
+        sa.Column("n_jacobians", sa.Integer(), nullable=False),
+        sa.Column("val_loss", sa.Float(), nullable=True),
+        sa.Column("train_loss", sa.Float(), nullable=True),
+        sa.Column(
+            "hyperparams_json",
+            sa.Text(),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+    op.create_index(
+        "ix_metric_fits_policy_id",
+        "metric_fits",
+        ["policy_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_metric_fits_policy_id", table_name="metric_fits")
+    op.drop_table("metric_fits")

--- a/alembic/versions/0009_structural_signals.py
+++ b/alembic/versions/0009_structural_signals.py
@@ -1,0 +1,62 @@
+"""structural_signals — fired-alerts feed for decoupling + curvature signals
+
+Revision ID: 0009_structural_signals
+Revises: 0008_metric_fits
+Create Date: 2026-05-01 00:01:00
+
+Phase 5's storage substrate for the structural early-warning signals
+defined in §6.4: decoupling (covariance flip between policy axes) and
+curvature (steeper local metric at the anchor's location). Each row
+is one fired alert with its scalar metric value, the threshold it
+crossed, and a JSON evidence blob explaining the fire (flipped pairs
+for decoupling, condition-number ratio for curvature). Issue #51's
+spec called this `0013_structural_signals`; we file it under the next
+free slot (0009) so the chain stays linear with `0008_metric_fits`.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009_structural_signals"
+down_revision: str | None = "0008_metric_fits"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "structural_signals",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("anchor_id", sa.String(length=64), nullable=False),
+        sa.Column("signal_type", sa.String(length=16), nullable=False),
+        sa.Column("metric_value", sa.Float(), nullable=False),
+        sa.Column("threshold", sa.Float(), nullable=False),
+        sa.Column(
+            "fired_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.current_timestamp(),
+        ),
+        sa.Column(
+            "evidence_json",
+            sa.Text(),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+    op.create_index(
+        "ix_structural_signals_anchor_id",
+        "structural_signals",
+        ["anchor_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_structural_signals_anchor_id",
+        table_name="structural_signals",
+    )
+    op.drop_table("structural_signals")

--- a/src/maimonedes/cli.py
+++ b/src/maimonedes/cli.py
@@ -60,6 +60,18 @@ from maimonedes.monitor.fragility import (
     aggregated_fragility,
     all_jacobians,
 )
+from maimonedes.monitor.metric import (
+    RiemannianMetric,
+    euclidean_distance,
+    fit_metric,
+    riemannian_distance,
+)
+from maimonedes.storage.metric_fits import (
+    get_metric_fit,
+    latest_metric_fit_for_policy,
+    list_metric_fits,
+    record_metric_fit,
+)
 from maimonedes.monitor.recovery_report import (
     NoRecoveryDataError,
     OrphanRecoveryRunError,
@@ -687,8 +699,13 @@ def induce_drift_cmd(
 
 
 def _format_report_table(report: DriftReport) -> list[str]:
-    """Plain-text table — grep-friendly, no rich. Returns lines."""
-    headers = (
+    """Plain-text table — grep-friendly, no rich. Returns lines.
+
+    When `report.has_riemannian_columns` is True, two extra columns
+    are appended: `eucl_d` and `riem_d` (worst-score displacement
+    from baseline, flat L2 vs learned metric).
+    """
+    base_headers = [
         "anchor",
         "n_sess",
         "mean_base",
@@ -697,7 +714,12 @@ def _format_report_table(report: DriftReport) -> list[str]:
         "cusum",
         "ewma",
         "lead",
-    )
+    ]
+    has_riem = report.has_riemannian_columns
+    if has_riem:
+        headers = (*base_headers, "eucl_d", "riem_d")
+    else:
+        headers = tuple(base_headers)
     rows: list[tuple[str, ...]] = []
     for r in report.rows:
         if r.detector_skipped:
@@ -732,18 +754,29 @@ def _format_report_table(report: DriftReport) -> list[str]:
                 lead = "+inf"
             else:
                 lead = f"{lead_v:+.0f}"
-        rows.append(
-            (
-                r.anchor_id,
-                str(r.n_sessions),
-                mean_base,
-                min_agg,
-                first_viol,
-                cusum,
-                ewma,
-                lead,
-            )
+        row: tuple[str, ...] = (
+            r.anchor_id,
+            str(r.n_sessions),
+            mean_base,
+            min_agg,
+            first_viol,
+            cusum,
+            ewma,
+            lead,
         )
+        if has_riem:
+            eucl_d = (
+                f"{r.euclidean_displacement:.3f}"
+                if r.euclidean_displacement is not None
+                else "-"
+            )
+            riem_d = (
+                f"{r.riemannian_displacement:.3f}"
+                if r.riemannian_displacement is not None
+                else "-"
+            )
+            row = (*row, eucl_d, riem_d)
+        rows.append(row)
     widths = [
         max(len(headers[i]), *(len(row[i]) for row in rows)) if rows else len(headers[i])
         for i in range(len(headers))
@@ -775,6 +808,12 @@ def drift_report_cmd(
     L: float = typer.Option(
         3.0, "--L", help="EWMA control-limit width in baseline σ."
     ),
+    metric_id: int | None = typer.Option(
+        None,
+        "--metric",
+        help="metric_fit id from `fit-metric`; when set, the report adds "
+        "Euclidean and Riemannian displacement columns side by side.",
+    ),
 ) -> None:
     """Print detection-latency summary for a drift run."""
     run = get_drift_run(run_id)
@@ -790,6 +829,14 @@ def drift_report_cmd(
             err=True,
         )
 
+    metric_obj: RiemannianMetric | None = None
+    if metric_id is not None:
+        fit = get_metric_fit(metric_id)
+        if fit is None:
+            typer.echo(f"unknown metric_fit_id: {metric_id}", err=True)
+            raise typer.Exit(code=4)
+        metric_obj = RiemannianMetric.load(Path(str(fit["path"])))
+
     try:
         report = build_report(
             run_id,
@@ -797,6 +844,8 @@ def drift_report_cmd(
             k=k,
             lambda_=lambda_,
             L=L,
+            metric=metric_obj,
+            metric_id=metric_id,
         )
     except NoBaselineDataError as exc:
         typer.echo(f"insufficient baseline data: {exc}", err=True)
@@ -1176,6 +1225,168 @@ def fragility_report_cmd(
         f"summary: anchors={len(jacobians)} kinds={len(table.perturbation_kinds)} "
         f"cells={len(table.cells)}"
     )
+
+
+DEFAULT_METRICS_DIR = Path("models")
+
+
+@app.command("fit-metric")
+def fit_metric_cmd(
+    policy_path: Path = typer.Option(DEFAULT_POLICY_PATH, "--policy"),
+    rubric_path: Path = typer.Option(DEFAULT_RUBRIC_PATH, "--rubric"),
+    hidden: int = typer.Option(
+        32, "--hidden", help="MLP hidden width (per layer)."
+    ),
+    depth: int = typer.Option(
+        2, "--depth", help="Number of hidden ReLU layers."
+    ),
+    epochs: int = typer.Option(
+        200, "--epochs", help="Training epochs (full passes over the anchor pairs)."
+    ),
+    l2: float = typer.Option(
+        1e-3, "--l2", help="L2 regularisation coefficient on weights."
+    ),
+    lr: float = typer.Option(
+        1e-2, "--lr", help="Adam learning rate."
+    ),
+    seed: int = typer.Option(
+        0, "--seed", help="RNG seed for MLP init + train/val split."
+    ),
+    output_dir: Path = typer.Option(
+        DEFAULT_METRICS_DIR,
+        "--output-dir",
+        help="Directory under which the trained metric `.npz` is written.",
+    ),
+) -> None:
+    """Fit a Riemannian metric on the anchor Jacobians and persist it."""
+    try:
+        policy = load_policy(policy_path, rubric_path)
+    except FileNotFoundError as exc:
+        typer.echo(f"config file not found: {exc}", err=True)
+        raise typer.Exit(code=5) from exc
+
+    try:
+        metric = fit_metric(
+            policy=policy,
+            hidden=hidden,
+            depth=depth,
+            epochs=epochs,
+            l2=l2,
+            lr=lr,
+            seed=seed,
+        )
+    except ValueError as exc:
+        typer.echo(f"fit failed: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    from datetime import datetime, timezone
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"metric_{policy.id}_{timestamp}.npz"
+    metric.save(out_path)
+
+    fit_id = record_metric_fit(
+        policy_id=policy.id,
+        path=str(out_path),
+        n_anchors=metric.n_anchors,
+        n_jacobians=metric.n_jacobians,
+        val_loss=metric.eval_metrics.get("val_loss"),
+        train_loss=metric.eval_metrics.get("train_loss"),
+        hyperparams={
+            "hidden": hidden,
+            "depth": depth,
+            "epochs": epochs,
+            "l2": l2,
+            "lr": lr,
+            "seed": seed,
+        },
+    )
+    typer.echo(
+        f"metric_fit_id={fit_id} policy={policy.id} "
+        f"n_anchors={metric.n_anchors} n_jacobians={metric.n_jacobians}"
+    )
+    typer.echo(
+        f"  train_loss={metric.eval_metrics.get('train_loss', float('nan')):.5f} "
+        f"val_loss={metric.eval_metrics.get('val_loss', float('nan')):.5f}"
+    )
+    typer.echo(f"  path={out_path}")
+
+
+@app.command("metric-distance")
+def metric_distance_cmd(
+    c0: str = typer.Argument(
+        ..., help="First compliance point — comma-separated floats, e.g. '0.89,0.85'."
+    ),
+    c1: str = typer.Argument(
+        ..., help="Second compliance point — comma-separated floats."
+    ),
+    metric_id: int | None = typer.Option(
+        None,
+        "--metric-id",
+        help="metric_fit_id from `fit-metric`. Defaults to the most recent "
+        "fit for the policy passed via --policy.",
+    ),
+    policy_path: Path = typer.Option(DEFAULT_POLICY_PATH, "--policy"),
+    rubric_path: Path = typer.Option(DEFAULT_RUBRIC_PATH, "--rubric"),
+    n_segments: int = typer.Option(
+        16,
+        "--segments",
+        help="Number of integration segments along the straight-line path.",
+    ),
+) -> None:
+    """Compare Euclidean and Riemannian distance for two compliance points."""
+    try:
+        c0_arr = [float(x.strip()) for x in c0.split(",") if x.strip()]
+        c1_arr = [float(x.strip()) for x in c1.split(",") if x.strip()]
+    except ValueError as exc:
+        raise typer.BadParameter(f"could not parse c0/c1 as floats: {exc}") from exc
+
+    if metric_id is None:
+        try:
+            policy = load_policy(policy_path, rubric_path)
+        except FileNotFoundError as exc:
+            typer.echo(f"config file not found: {exc}", err=True)
+            raise typer.Exit(code=5) from exc
+        latest = latest_metric_fit_for_policy(policy.id)
+        if latest is None:
+            typer.echo(
+                f"no metric_fit found for policy={policy.id}; "
+                f"run `maimonedes fit-metric` first",
+                err=True,
+            )
+            raise typer.Exit(code=4)
+        metric_id_used = int(latest["id"])  # type: ignore[arg-type]
+        path = str(latest["path"])
+    else:
+        fit = get_metric_fit(metric_id)
+        if fit is None:
+            typer.echo(f"unknown metric_fit_id: {metric_id}", err=True)
+            raise typer.Exit(code=4)
+        metric_id_used = metric_id
+        path = str(fit["path"])
+
+    metric = RiemannianMetric.load(Path(path))
+    if len(c0_arr) != metric.k or len(c1_arr) != metric.k:
+        typer.echo(
+            f"compliance vectors must have k={metric.k} components; "
+            f"got len(c0)={len(c0_arr)}, len(c1)={len(c1_arr)}",
+            err=True,
+        )
+        raise typer.Exit(code=5)
+
+    import numpy as np
+    c0_np = np.asarray(c0_arr, dtype=np.float64)
+    c1_np = np.asarray(c1_arr, dtype=np.float64)
+    d_eucl = euclidean_distance(c0_np, c1_np)
+    d_riem = riemannian_distance(metric, c0_np, c1_np, n_segments=n_segments)
+    ratio = d_riem / d_eucl if d_eucl > 1e-12 else float("inf")
+
+    typer.echo(f"metric_fit_id={metric_id_used} path={path}")
+    typer.echo(f"c0={c0_arr}")
+    typer.echo(f"c1={c1_arr}")
+    typer.echo(f"euclidean_distance = {d_eucl:.6f}")
+    typer.echo(f"riemannian_distance = {d_riem:.6f}")
+    typer.echo(f"ratio (riem/eucl) = {ratio:.3f}")
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/maimonedes/monitor/curvature.py
+++ b/src/maimonedes/monitor/curvature.py
@@ -1,0 +1,132 @@
+"""Phase 5 curvature signal (issue #51).
+
+Detects geometric reorganisation: the supervised system's compliance
+landscape becomes more sharply curved at an anchor's location even
+though the anchor's positional drift is zero. v1 expresses
+"curvature" as the condition number of the local metric tensor —
+`κ(g) = λ_max / λ_min` — which captures the §6.4 narrative ("the
+metric at an anchor location shows increasing curvature — the
+compliance landscape is becoming steeper") without needing to compute
+a full Ricci scalar (deferred to v3 per the issue's implementation
+notes).
+
+Signal fires when `(κ_current - κ_baseline) / κ_baseline > h_curvature`.
+Default `h_curvature = 0.5` — a 50% relative increase — picked to
+match the same "structural alarm" sensitivity that CUSUM operates at.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from maimonedes.monitor.metric import RiemannianMetric, metric_at
+
+
+DEFAULT_H_CURVATURE = 0.5
+
+
+@dataclass(frozen=True)
+class CurvatureResult:
+    """One anchor's curvature-drift verdict.
+
+    Stored as the condition-number scalar at both fits plus the
+    relative-increase ratio for convenient threshold tuning.
+    """
+
+    anchor_id: str
+    c: tuple[float, ...]
+    baseline_curvature: float
+    current_curvature: float
+    relative_increase: float
+    signal_fired: bool
+    h_curvature: float
+
+
+def compute_curvature(metric: RiemannianMetric, c: np.ndarray) -> float:
+    """Scalar curvature at point `c` — condition number `λ_max / λ_min`.
+
+    Raises `ValueError` if the metric is degenerate (smallest eigen-
+    value below 1e-12). The Cholesky parameterisation guarantees PD
+    so this only triggers in pathological numerical cases.
+    """
+    g = metric_at(metric, c)
+    eigvals = np.linalg.eigvalsh(g)
+    lam_min = float(eigvals.min())
+    lam_max = float(eigvals.max())
+    if lam_min <= 1e-12:
+        raise ValueError(
+            f"compute_curvature: metric is near-degenerate at c={c.tolist()}: "
+            f"min eigenvalue {lam_min:.3e}"
+        )
+    return lam_max / lam_min
+
+
+def curvature_drift(
+    *,
+    anchor_id: str,
+    metric_baseline: RiemannianMetric,
+    metric_current: RiemannianMetric,
+    c: np.ndarray,
+    h_curvature: float = DEFAULT_H_CURVATURE,
+) -> CurvatureResult:
+    """Compare condition numbers at the same `c` between two metric fits.
+
+    Both metrics must agree on `k` (the issue's v1 only supports per-
+    policy metrics; cross-policy curvature is v3). Fires when the
+    relative increase exceeds `h_curvature`.
+    """
+    if metric_baseline.k != metric_current.k:
+        raise ValueError(
+            f"curvature_drift: metric dimensionality mismatch — "
+            f"baseline k={metric_baseline.k}, current k={metric_current.k}"
+        )
+    c_arr = np.asarray(c, dtype=np.float64).reshape(-1)
+    if c_arr.size != metric_baseline.k:
+        raise ValueError(
+            f"curvature_drift: c shape {c_arr.shape}; expected ({metric_baseline.k},)"
+        )
+
+    base_kappa = compute_curvature(metric_baseline, c_arr)
+    cur_kappa = compute_curvature(metric_current, c_arr)
+    rel_increase = (cur_kappa - base_kappa) / base_kappa
+    fired = rel_increase > h_curvature
+
+    return CurvatureResult(
+        anchor_id=anchor_id,
+        c=tuple(float(v) for v in c_arr),
+        baseline_curvature=base_kappa,
+        current_curvature=cur_kappa,
+        relative_increase=rel_increase,
+        signal_fired=fired,
+        h_curvature=h_curvature,
+    )
+
+
+def curvature_per_anchor(
+    anchor_positions: dict[str, np.ndarray],
+    *,
+    metric_baseline: RiemannianMetric,
+    metric_current: RiemannianMetric,
+    h_curvature: float = DEFAULT_H_CURVATURE,
+) -> dict[str, CurvatureResult]:
+    """Run `curvature_drift` for every (anchor_id, c) pair."""
+    out: dict[str, CurvatureResult] = {}
+    for aid, c in anchor_positions.items():
+        out[aid] = curvature_drift(
+            anchor_id=aid,
+            metric_baseline=metric_baseline,
+            metric_current=metric_current,
+            c=c,
+            h_curvature=h_curvature,
+        )
+    return out
+
+
+__all__ = [
+    "CurvatureResult",
+    "DEFAULT_H_CURVATURE",
+    "compute_curvature",
+    "curvature_drift",
+    "curvature_per_anchor",
+]

--- a/src/maimonedes/monitor/decoupling.py
+++ b/src/maimonedes/monitor/decoupling.py
@@ -1,0 +1,268 @@
+"""Phase 5 decoupling signal (issue #51).
+
+Detects structural reorganisation that single-axis monitors miss:
+when the off-diagonal terms in the per-axis covariance matrix flip
+sign (or shift in Frobenius norm beyond a threshold), the supervised
+system's internal policy representation has reorganised even if no
+individual axis has crossed a violation line.
+
+Mirror of the §4.6 Example 4 framing: at t₀, perturbation experiments
+show strong positive correlation between scope compliance and
+calibration compliance. At t₃, the correlation has flipped — the
+system is becoming more hedged precisely when pushed toward
+unsanctioned actions. Position is unchanged. Fragility per-axis is
+unchanged. Only the covariance structure has moved.
+
+Shape of the algorithm:
+1. Pull the most recent `window` perturbation-stage compliance scores
+   for the anchor (newest first).
+2. Stack the per-axis vectors into a `(window, k)` matrix.
+3. Compute the empirical k×k covariance with Bessel's correction
+   (`ddof=1`).
+4. Compare baseline-window covariance vs current-window covariance.
+   Fire on any of:
+   - Off-diagonal sign flip — `baseline[i,j]` and `current[i,j]` lie
+     on opposite sides of ±ε for any `(i,j)` with `i != j`.
+   - Frobenius norm of the difference exceeds `h_decoupling`.
+
+`h_decoupling` is per-anchor, derived from the same baseline-noise
+philosophy as CUSUM's `h`. v1 default: `4σ_baseline`, where σ is the
+Frobenius norm of the bootstrap distribution of baseline-window
+covariance differences. Tuning is exposed via the `h_decoupling`
+kwarg so the dashboard / CLI can override.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import numpy as np
+from sqlalchemy import select
+
+from maimonedes.core.compliance import ComplianceScore
+from maimonedes.storage.compliance import ComplianceScoreRow, row_to_score
+from maimonedes.storage.repo import get_session
+
+
+SIGN_FLIP_EPS = 1e-3
+
+
+@dataclass(frozen=True)
+class DecouplingResult:
+    """One anchor's decoupling-signal verdict.
+
+    `flipped_pairs` lists `(i, j)` indices into the canonical axis
+    order (`axis_ids`) where the off-diagonal covariance changed sign.
+    `frobenius_delta` is `‖current_cov - baseline_cov‖_F`.
+    """
+
+    anchor_id: str
+    axis_ids: tuple[str, ...]
+    flipped_pairs: list[tuple[int, int]]
+    frobenius_delta: float
+    baseline_cov: np.ndarray
+    current_cov: np.ndarray
+    signal_fired: bool
+    evidence_count: int  # samples used in current window
+    h_decoupling: float
+
+    @property
+    def k(self) -> int:
+        return len(self.axis_ids)
+
+
+def _scores_to_matrix(
+    scores: Sequence[ComplianceScore], axis_ids: Sequence[str]
+) -> np.ndarray:
+    """Stack scores' per_sub_condition vectors into a (n, k) matrix.
+
+    Missing axes default to 0.0 — keeps the matrix shape invariant
+    when an anchor's stream straddles a rubric change.
+    """
+    if not scores:
+        return np.zeros((0, len(axis_ids)), dtype=np.float64)
+    return np.asarray(
+        [[s.per_sub_condition.get(a, 0.0) for a in axis_ids] for s in scores],
+        dtype=np.float64,
+    )
+
+
+def _empirical_covariance(matrix: np.ndarray) -> np.ndarray:
+    """k×k covariance with Bessel's correction (`ddof=1`).
+
+    Returns zeros when `matrix` has fewer than 2 rows — too few
+    samples to estimate covariance.
+    """
+    n, k = matrix.shape
+    if n < 2:
+        return np.zeros((k, k), dtype=np.float64)
+    centred = matrix - matrix.mean(axis=0, keepdims=True)
+    return (centred.T @ centred) / (n - 1)
+
+
+def _recent_perturbation_scores(
+    anchor_id: str, *, limit: int
+) -> list[ComplianceScore]:
+    """Most-recent `limit` perturbation-stage scores for `anchor_id`.
+
+    Newest-first order; the caller decides whether to read from the
+    head (current window) or skip past `current_window` to reach the
+    baseline window.
+    """
+    with get_session() as session:
+        rows = session.execute(
+            select(ComplianceScoreRow)
+            .where(
+                ComplianceScoreRow.anchor_id == anchor_id,
+                ComplianceScoreRow.probe_role == "perturbation",
+            )
+            .order_by(
+                ComplianceScoreRow.scored_at.desc(),
+                ComplianceScoreRow.id.desc(),
+            )
+            .limit(limit)
+        ).scalars().all()
+        return [row_to_score(r) for r in rows]
+
+
+def compute_axis_covariance(
+    *,
+    anchor_id: str,
+    axis_ids: Sequence[str],
+    window: int = 50,
+) -> np.ndarray:
+    """Empirical k×k covariance over the `window` most-recent perturbation scores.
+
+    `axis_ids` fixes the column order; pass the policy's
+    `rubric.sub_conditions[i].id` list to keep covariance comparable
+    across calls (and to pair with a `RiemannianMetric.sub_condition_ids`).
+    """
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    scores = _recent_perturbation_scores(anchor_id, limit=window)
+    matrix = _scores_to_matrix(scores, axis_ids)
+    return _empirical_covariance(matrix)
+
+
+def _off_diagonal_sign_flips(
+    baseline: np.ndarray, current: np.ndarray, *, eps: float = SIGN_FLIP_EPS
+) -> list[tuple[int, int]]:
+    """Indices `(i, j)` (i < j) where the off-diagonal covariance flipped.
+
+    A flip means baseline > +eps and current < -eps (or vice versa).
+    Equal-zero pairs are ignored — a zero-correlation pair does not
+    have a "sign" to flip.
+    """
+    k = baseline.shape[0]
+    out: list[tuple[int, int]] = []
+    for i in range(k):
+        for j in range(i + 1, k):
+            b = baseline[i, j]
+            c = current[i, j]
+            if b > eps and c < -eps:
+                out.append((i, j))
+            elif b < -eps and c > eps:
+                out.append((i, j))
+    return out
+
+
+def decoupling_signal(
+    *,
+    anchor_id: str,
+    axis_ids: Sequence[str],
+    baseline_window: int = 50,
+    current_window: int = 20,
+    h_decoupling: float | None = None,
+    sign_flip_eps: float = SIGN_FLIP_EPS,
+) -> DecouplingResult:
+    """Compute baseline-vs-current covariance comparison for one anchor.
+
+    `baseline_window` and `current_window` are sample counts of
+    perturbation-stage scores (ordered newest-first). With fewer than
+    `current_window` samples available the result still computes but
+    `signal_fired` is False (insufficient evidence).
+
+    `h_decoupling` defaults to `4 × ‖baseline_cov‖_F` — same shape as
+    CUSUM's `h = k·σ`, with σ proxied by the baseline-cov magnitude.
+    Pass an explicit value to override (e.g. when the dashboard
+    persists tuned thresholds per anchor).
+    """
+    axis_ids_tuple = tuple(axis_ids)
+    if not axis_ids_tuple:
+        raise ValueError("axis_ids must be non-empty")
+    if baseline_window < 2 or current_window < 2:
+        raise ValueError("windows must be >= 2 to estimate covariance")
+
+    # Pull baseline_window + current_window most-recent rows; the head
+    # of the list is the current window, the tail is the baseline.
+    total = baseline_window + current_window
+    scores = _recent_perturbation_scores(anchor_id, limit=total)
+    current_scores = scores[:current_window]
+    baseline_scores = scores[current_window:]
+
+    current_matrix = _scores_to_matrix(current_scores, axis_ids_tuple)
+    baseline_matrix = _scores_to_matrix(baseline_scores, axis_ids_tuple)
+
+    current_cov = _empirical_covariance(current_matrix)
+    baseline_cov = _empirical_covariance(baseline_matrix)
+
+    diff = current_cov - baseline_cov
+    frob_delta = float(np.linalg.norm(diff, ord="fro"))
+    flipped = _off_diagonal_sign_flips(
+        baseline_cov, current_cov, eps=sign_flip_eps
+    )
+
+    if h_decoupling is None:
+        # Default threshold: 4× the Frobenius magnitude of the baseline
+        # covariance (mirrors CUSUM's h = k·σ where σ is the baseline
+        # noise). Anchor with an all-zero baseline gets a tiny floor.
+        baseline_norm = float(np.linalg.norm(baseline_cov, ord="fro"))
+        h_decoupling = max(4.0 * baseline_norm, 0.05)
+
+    has_evidence = (
+        current_matrix.shape[0] >= max(2, current_window // 2)
+        and baseline_matrix.shape[0] >= max(2, baseline_window // 4)
+    )
+    fired = has_evidence and (
+        len(flipped) > 0 or frob_delta > h_decoupling
+    )
+
+    return DecouplingResult(
+        anchor_id=anchor_id,
+        axis_ids=axis_ids_tuple,
+        flipped_pairs=flipped,
+        frobenius_delta=frob_delta,
+        baseline_cov=baseline_cov,
+        current_cov=current_cov,
+        signal_fired=fired,
+        evidence_count=current_matrix.shape[0],
+        h_decoupling=h_decoupling,
+    )
+
+
+def decoupling_per_anchor(
+    anchor_ids: Iterable[str],
+    *,
+    axis_ids: Sequence[str],
+    baseline_window: int = 50,
+    current_window: int = 20,
+) -> dict[str, DecouplingResult]:
+    """Convenience: run `decoupling_signal` across many anchors."""
+    out: dict[str, DecouplingResult] = {}
+    for aid in anchor_ids:
+        out[aid] = decoupling_signal(
+            anchor_id=aid,
+            axis_ids=axis_ids,
+            baseline_window=baseline_window,
+            current_window=current_window,
+        )
+    return out
+
+
+__all__ = [
+    "DecouplingResult",
+    "compute_axis_covariance",
+    "decoupling_per_anchor",
+    "decoupling_signal",
+]

--- a/src/maimonedes/monitor/drift_report.py
+++ b/src/maimonedes/monitor/drift_report.py
@@ -5,11 +5,16 @@ EWMA, and computes the first-violation index. The result is a list
 of `AnchorReportRow` plus aggregate footer numbers — the CLI and
 dashboard format the same data structure.
 
-Phase 5 add-on (issue #50): when a `RiemannianMetric` is supplied,
-each row gains optional Euclidean / Riemannian displacement columns
-that compare how far the anchor's worst-session score sits from its
-baseline position under both metrics — flat L2 vs the learned
-geodesic-style integral.
+Phase 5 add-ons:
+- Issue #50: when a `RiemannianMetric` is supplied via `metric=`,
+  each row gains Euclidean / Riemannian displacement columns that
+  compare how far the anchor's worst-session score sits from its
+  baseline under flat L2 vs the learned geodesic-style integral.
+- Issue #51: structural signals (decoupling + curvature) layer on
+  top: decoupling fires when the per-axis covariance flips, curvature
+  fires when the local metric becomes more anisotropic. Both are
+  enabled with the same `metric=` flag (curvature needs two metric
+  fits — passed as `metric_baseline=` and `metric_current=`).
 """
 from __future__ import annotations
 
@@ -23,6 +28,15 @@ from maimonedes.monitor._baseline import (
     load_run_scalars,
 )
 from maimonedes.monitor.cusum import cusum_per_anchor
+from maimonedes.monitor.curvature import (
+    CurvatureResult,
+    DEFAULT_H_CURVATURE,
+    curvature_drift,
+)
+from maimonedes.monitor.decoupling import (
+    DecouplingResult,
+    decoupling_signal,
+)
 from maimonedes.monitor.ewma import ewma_per_anchor
 from maimonedes.monitor.metric import (
     RiemannianMetric,
@@ -36,9 +50,10 @@ from maimonedes.storage.drift import scores_for_run
 class AnchorReportRow:
     """One anchor's view of detection latency for a drift run.
 
-    `euclidean_displacement` and `riemannian_displacement` are populated
-    only when `build_report(..., metric=...)` is called; both are None
-    in the default flat-Euclidean-only mode so existing callers stay
+    `euclidean_displacement` / `riemannian_displacement` are populated
+    only when `build_report(..., metric=...)` is called; `decoupling`
+    and `curvature` are populated only when their respective inputs
+    are supplied. All three default to None so existing callers stay
     unchanged.
     """
 
@@ -52,6 +67,8 @@ class AnchorReportRow:
     ewma_first_fire: int | None
     euclidean_displacement: float | None = None
     riemannian_displacement: float | None = None
+    decoupling: DecouplingResult | None = None
+    curvature: CurvatureResult | None = None
 
     @property
     def detector_skipped(self) -> bool:
@@ -70,6 +87,14 @@ class AnchorReportRow:
         if self.first_violation_session is None:
             return math.inf
         return float(self.first_violation_session - self.cusum_first_fire)
+
+    @property
+    def decoupling_fired(self) -> bool:
+        return self.decoupling is not None and self.decoupling.signal_fired
+
+    @property
+    def curvature_fired(self) -> bool:
+        return self.curvature is not None and self.curvature.signal_fired
 
 
 @dataclass(frozen=True)
@@ -91,6 +116,13 @@ class DriftReport:
     @property
     def has_riemannian_columns(self) -> bool:
         return any(r.riemannian_displacement is not None for r in self.rows)
+
+    @property
+    def has_structural_columns(self) -> bool:
+        return any(
+            r.decoupling is not None or r.curvature is not None
+            for r in self.rows
+        )
 
 
 class NoBaselineDataError(Exception):
@@ -146,6 +178,49 @@ def _compute_displacement_columns(
     return out
 
 
+def _structural_signals_for_anchor(
+    anchor_id: str,
+    *,
+    axis_ids: tuple[str, ...] | list[str] | None,
+    metric_baseline: RiemannianMetric | None,
+    metric_current: RiemannianMetric | None,
+    anchor_position: np.ndarray | None,
+    decoupling_baseline_window: int,
+    decoupling_current_window: int,
+    h_curvature: float,
+) -> tuple[DecouplingResult | None, CurvatureResult | None]:
+    """Run decoupling + curvature for one anchor, returning (None, None) when inputs missing."""
+    decoupling: DecouplingResult | None = None
+    curvature: CurvatureResult | None = None
+    if axis_ids:
+        try:
+            decoupling = decoupling_signal(
+                anchor_id=anchor_id,
+                axis_ids=axis_ids,
+                baseline_window=decoupling_baseline_window,
+                current_window=decoupling_current_window,
+            )
+        except ValueError:
+            # Insufficient samples — leave as None.
+            decoupling = None
+    if (
+        metric_baseline is not None
+        and metric_current is not None
+        and anchor_position is not None
+    ):
+        try:
+            curvature = curvature_drift(
+                anchor_id=anchor_id,
+                metric_baseline=metric_baseline,
+                metric_current=metric_current,
+                c=anchor_position,
+                h_curvature=h_curvature,
+            )
+        except ValueError:
+            curvature = None
+    return decoupling, curvature
+
+
 def build_report(
     run_id: int,
     *,
@@ -155,14 +230,28 @@ def build_report(
     L: float = 3.0,
     metric: RiemannianMetric | None = None,
     metric_id: int | None = None,
+    metric_baseline: RiemannianMetric | None = None,
+    metric_current: RiemannianMetric | None = None,
+    decoupling_baseline_window: int = 50,
+    decoupling_current_window: int = 20,
+    h_curvature: float = DEFAULT_H_CURVATURE,
 ) -> DriftReport:
     """Assemble the detection-latency report for one drift run.
 
     Raises `NoBaselineDataError` when no anchor has at least 5
     baseline-stage samples — the caller (CLI) translates this to a
     clear exit-code-2 message rather than producing a half-formed
-    report. When `metric` is supplied, each row carries an extra
-    Euclidean/Riemannian displacement pair for side-by-side reporting.
+    report.
+
+    Optional add-ons:
+    - `metric=...` (issue #50): per-row Euclidean/Riemannian
+      displacement columns relative to the worst-session score.
+    - `metric_baseline=` + `metric_current=` (issue #51): per-row
+      curvature-drift signal — fires when the local condition number
+      jumped between fits.
+    - decoupling signal (issue #51): always runs when `metric` is
+      supplied (uses its `sub_condition_ids` for the canonical axis
+      order); disabled by passing `metric=None`.
     """
     streams = load_run_scalars(run_id)
     if not streams:
@@ -176,6 +265,14 @@ def build_report(
     displacements: dict[str, tuple[float | None, float | None]] = {}
     if metric is not None:
         displacements = _compute_displacement_columns(run_id, metric=metric)
+
+    structural_axes: tuple[str, ...] | None = None
+    if metric is not None and metric.sub_condition_ids:
+        structural_axes = tuple(metric.sub_condition_ids)
+    elif metric_current is not None and metric_current.sub_condition_ids:
+        structural_axes = tuple(metric_current.sub_condition_ids)
+
+    full_streams = scores_for_run(run_id) if structural_axes is not None else {}
 
     rows: list[AnchorReportRow] = []
     any_baseline = False
@@ -199,6 +296,36 @@ def build_report(
         ewma_fire = next((s.session_index for s in ewma_states if s.fired), None)
 
         eucl_disp, riem_disp = displacements.get(anchor_id, (None, None))
+
+        anchor_position: np.ndarray | None = None
+        if structural_axes is not None:
+            anchor_scores = full_streams.get(anchor_id, [])
+            if anchor_scores:
+                # Mean across baseline-stage observations — proxied by
+                # the highest-aggregate window (matches the localizer).
+                sorted_by_agg = sorted(
+                    anchor_scores, key=lambda s: s.aggregate, reverse=True
+                )
+                head = sorted_by_agg[: max(1, len(sorted_by_agg) // 2)]
+                anchor_position = np.mean(
+                    [
+                        [s.per_sub_condition.get(a, 0.0) for a in structural_axes]
+                        for s in head
+                    ],
+                    axis=0,
+                )
+
+        decoupling_res, curvature_res = _structural_signals_for_anchor(
+            anchor_id,
+            axis_ids=structural_axes,
+            metric_baseline=metric_baseline,
+            metric_current=metric_current,
+            anchor_position=anchor_position,
+            decoupling_baseline_window=decoupling_baseline_window,
+            decoupling_current_window=decoupling_current_window,
+            h_curvature=h_curvature,
+        )
+
         rows.append(
             AnchorReportRow(
                 anchor_id=anchor_id,
@@ -213,6 +340,8 @@ def build_report(
                 ewma_first_fire=ewma_fire,
                 euclidean_displacement=eucl_disp,
                 riemannian_displacement=riem_disp,
+                decoupling=decoupling_res,
+                curvature=curvature_res,
             )
         )
 

--- a/src/maimonedes/monitor/drift_report.py
+++ b/src/maimonedes/monitor/drift_report.py
@@ -4,11 +4,19 @@ Pulls per-anchor scalar streams for one drift run, runs CUSUM and
 EWMA, and computes the first-violation index. The result is a list
 of `AnchorReportRow` plus aggregate footer numbers — the CLI and
 dashboard format the same data structure.
+
+Phase 5 add-on (issue #50): when a `RiemannianMetric` is supplied,
+each row gains optional Euclidean / Riemannian displacement columns
+that compare how far the anchor's worst-session score sits from its
+baseline position under both metrics — flat L2 vs the learned
+geodesic-style integral.
 """
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+
+import numpy as np
 
 from maimonedes.monitor._baseline import (
     InsufficientBaseline,
@@ -16,11 +24,23 @@ from maimonedes.monitor._baseline import (
 )
 from maimonedes.monitor.cusum import cusum_per_anchor
 from maimonedes.monitor.ewma import ewma_per_anchor
+from maimonedes.monitor.metric import (
+    RiemannianMetric,
+    euclidean_distance,
+    riemannian_distance,
+)
+from maimonedes.storage.drift import scores_for_run
 
 
 @dataclass(frozen=True)
 class AnchorReportRow:
-    """One anchor's view of detection latency for a drift run."""
+    """One anchor's view of detection latency for a drift run.
+
+    `euclidean_displacement` and `riemannian_displacement` are populated
+    only when `build_report(..., metric=...)` is called; both are None
+    in the default flat-Euclidean-only mode so existing callers stay
+    unchanged.
+    """
 
     anchor_id: str
     n_sessions: int
@@ -30,6 +50,8 @@ class AnchorReportRow:
     first_violation_session: int | None
     cusum_first_fire: int | None
     ewma_first_fire: int | None
+    euclidean_displacement: float | None = None
+    riemannian_displacement: float | None = None
 
     @property
     def detector_skipped(self) -> bool:
@@ -56,6 +78,7 @@ class DriftReport:
     earliest_cusum_fire: tuple[str, int] | None  # (anchor_id, session_index)
     earliest_violation: tuple[str, int] | None
     headline_lead_sessions: float | None  # violation - cusum, +inf if no violation
+    metric_id: int | None = None  # populated when --metric was supplied
 
     @property
     def has_data(self) -> bool:
@@ -65,9 +88,62 @@ class DriftReport:
     def has_any_baseline(self) -> bool:
         return any(r.n_baseline >= 5 for r in self.rows)
 
+    @property
+    def has_riemannian_columns(self) -> bool:
+        return any(r.riemannian_displacement is not None for r in self.rows)
+
 
 class NoBaselineDataError(Exception):
     """Raised when a drift run has no baseline-stage sessions across any anchor."""
+
+
+def _compute_displacement_columns(
+    run_id: int,
+    *,
+    metric: RiemannianMetric,
+) -> dict[str, tuple[float | None, float | None]]:
+    """Per-anchor (Euclidean, Riemannian) displacements for the worst score.
+
+    Reads the full per-axis stream for the run (via `scores_for_run`),
+    builds each anchor's mean baseline position c_baseline (over its
+    early scores — proxy for the baseline stage), then locates the
+    worst (lowest aggregate) score and computes both distances from
+    c_baseline to that worst score's per-axis position.
+    """
+    streams_full = scores_for_run(run_id)
+    axes = list(metric.sub_condition_ids) if metric.sub_condition_ids else None
+    out: dict[str, tuple[float | None, float | None]] = {}
+    for anchor_id, scores in streams_full.items():
+        if not scores:
+            out[anchor_id] = (None, None)
+            continue
+        per_axis_keys = axes or sorted(scores[0].per_sub_condition.keys())
+        if not per_axis_keys:
+            out[anchor_id] = (None, None)
+            continue
+        # Baseline window: the highest-aggregate sample is closest to
+        # the uncontaminated state (matches localizer's baseline pick).
+        sorted_by_agg = sorted(scores, key=lambda s: s.aggregate, reverse=True)
+        baseline_pool = sorted_by_agg[: max(1, len(sorted_by_agg) // 2)]
+        c_baseline = np.mean(
+            [
+                [s.per_sub_condition.get(a, 0.0) for a in per_axis_keys]
+                for s in baseline_pool
+            ],
+            axis=0,
+        )
+        worst = min(scores, key=lambda s: s.aggregate)
+        c_worst = np.asarray(
+            [worst.per_sub_condition.get(a, 0.0) for a in per_axis_keys],
+            dtype=np.float64,
+        )
+        if c_worst.size != metric.k:
+            out[anchor_id] = (None, None)
+            continue
+        d_eucl = euclidean_distance(c_baseline, c_worst)
+        d_riem = riemannian_distance(metric, c_baseline, c_worst)
+        out[anchor_id] = (d_eucl, d_riem)
+    return out
 
 
 def build_report(
@@ -77,13 +153,16 @@ def build_report(
     k: float = 4.0,
     lambda_: float = 0.2,
     L: float = 3.0,
+    metric: RiemannianMetric | None = None,
+    metric_id: int | None = None,
 ) -> DriftReport:
     """Assemble the detection-latency report for one drift run.
 
     Raises `NoBaselineDataError` when no anchor has at least 5
     baseline-stage samples — the caller (CLI) translates this to a
     clear exit-code-2 message rather than producing a half-formed
-    report.
+    report. When `metric` is supplied, each row carries an extra
+    Euclidean/Riemannian displacement pair for side-by-side reporting.
     """
     streams = load_run_scalars(run_id)
     if not streams:
@@ -93,6 +172,10 @@ def build_report(
 
     cusum_traces = cusum_per_anchor(run_id, k=k)
     ewma_traces = ewma_per_anchor(run_id, lambda_=lambda_, L=L)
+
+    displacements: dict[str, tuple[float | None, float | None]] = {}
+    if metric is not None:
+        displacements = _compute_displacement_columns(run_id, metric=metric)
 
     rows: list[AnchorReportRow] = []
     any_baseline = False
@@ -115,6 +198,7 @@ def build_report(
         ewma_states = ewma_traces.get(anchor_id, [])
         ewma_fire = next((s.session_index for s in ewma_states if s.fired), None)
 
+        eucl_disp, riem_disp = displacements.get(anchor_id, (None, None))
         rows.append(
             AnchorReportRow(
                 anchor_id=anchor_id,
@@ -127,6 +211,8 @@ def build_report(
                 first_violation_session=first_violation,
                 cusum_first_fire=cusum_fire,
                 ewma_first_fire=ewma_fire,
+                euclidean_displacement=eucl_disp,
+                riemannian_displacement=riem_disp,
             )
         )
 
@@ -165,6 +251,7 @@ def build_report(
         earliest_cusum_fire=earliest_cusum,
         earliest_violation=earliest_violation,
         headline_lead_sessions=headline,
+        metric_id=metric_id,
     )
 
 

--- a/src/maimonedes/monitor/localizer.py
+++ b/src/maimonedes/monitor/localizer.py
@@ -12,6 +12,13 @@ Distance:
     d(s) = sqrt( Σ w_i · max(0, τ_i - s_i)^2 )
     τ_i = 0.5
     w_i = rubric.sub_conditions[i].weight
+
+Riemannian variant (issue #50): when a `RiemannianMetric` is supplied
+via `metric=...`, the boundary distance switches to the Riemannian
+length from the score's current position to its axis-wise projection
+on the boundary box (still using the per-axis midpoint thresholds).
+Local geometry comes from the learned metric tensor; v2 can swap in
+a true geodesic ODE for off-diagonal-coupled boundaries.
 """
 from __future__ import annotations
 
@@ -19,8 +26,11 @@ import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import numpy as np
+
 from maimonedes.core.compliance import ComplianceScore
 from maimonedes.core.policy import Policy
+from maimonedes.monitor.metric import RiemannianMetric, riemannian_distance
 from maimonedes.storage.drift import scores_for_run
 
 
@@ -56,22 +66,59 @@ def boundary_distance(
     *,
     thresholds: dict[str, float],
     weights: dict[str, float],
+    metric: RiemannianMetric | None = None,
 ) -> float:
-    """Rubric-weighted L2 distance from a score vector to the boundary.
+    """Rubric-weighted distance from a score vector to the boundary.
 
-    Axes at or above their threshold contribute zero. Axes below their
-    threshold contribute `w_i · (τ_i - s_i)^2`. Distance is the sqrt
-    of the sum.
+    Default (`metric=None`): rubric-weighted Euclidean L2 — axes at or
+    above their threshold contribute zero, axes below contribute
+    `w_i · (τ_i - s_i)^2`. Distance is the sqrt of the sum.
+
+    Riemannian (`metric` set): integrate the learned metric along a
+    straight-line path in compliance space from the score's current
+    position to its axis-wise projection on the boundary box. Weights
+    are folded into the path's per-axis displacement so an axis's
+    relative importance still drives the magnitude.
     """
-    accum = 0.0
-    for sub_id, threshold in thresholds.items():
-        s_i = score.per_sub_condition.get(sub_id, 0.0)
-        margin = threshold - s_i
-        if margin <= 0:
-            continue
-        w_i = weights.get(sub_id, 0.0)
-        accum += w_i * margin * margin
-    return math.sqrt(accum)
+    if metric is None:
+        accum = 0.0
+        for sub_id, threshold in thresholds.items():
+            s_i = score.per_sub_condition.get(sub_id, 0.0)
+            margin = threshold - s_i
+            if margin <= 0:
+                continue
+            w_i = weights.get(sub_id, 0.0)
+            accum += w_i * margin * margin
+        return math.sqrt(accum)
+
+    # Riemannian: project onto the boundary box (only axes that crossed
+    # the threshold contribute), apply weights to the displacement, and
+    # measure path length under the learned metric.
+    axes = sorted(thresholds.keys())
+    if metric.sub_condition_ids:
+        # Keep the metric's training axis order so g(c) is evaluated on
+        # vectors aligned with the original Cholesky parameters.
+        axes = [a for a in metric.sub_condition_ids if a in thresholds]
+        if not axes:
+            return 0.0
+    c_now = np.asarray(
+        [score.per_sub_condition.get(a, 0.0) for a in axes],
+        dtype=np.float64,
+    )
+    c_target = c_now.copy()
+    has_violation = False
+    for i, sub_id in enumerate(axes):
+        threshold = thresholds[sub_id]
+        margin = threshold - c_now[i]
+        if margin > 0:
+            has_violation = True
+            w_i = weights.get(sub_id, 1.0)
+            # Weight scales the *amount* we move toward the boundary;
+            # higher-weight axes pull harder on the path.
+            c_target[i] = c_now[i] + math.sqrt(max(w_i, 0.0)) * margin
+    if not has_violation:
+        return 0.0
+    return riemannian_distance(metric, c_now, c_target)
 
 
 def worst_session_score(scores: Sequence[ComplianceScore]) -> ComplianceScore:
@@ -101,12 +148,17 @@ def localize(
     *,
     policy: Policy,
     top_k: int | None = None,
+    metric: RiemannianMetric | None = None,
 ) -> list[LocalizationResult]:
     """Rank anchors by descending boundary distance for one drift run.
 
     Anchors with no scores at all are omitted from the result rather
     than listed with distance 0 (which would suggest a safe anchor
-    rather than an absent one).
+    rather than an absent one). When `metric` is supplied, the per-
+    anchor distance is geodesic-style (Riemannian) instead of flat;
+    ranking can change because the same Euclidean displacement can
+    correspond to wildly different Riemannian distances depending on
+    where the score sits in compliance space.
     """
     streams = scores_for_run(run_id)
     if not streams:
@@ -122,7 +174,7 @@ def localize(
         worst = worst_session_score(scores)
         baseline = _baseline_anchor_score(scores)
         distance = boundary_distance(
-            worst, thresholds=thresholds, weights=weights
+            worst, thresholds=thresholds, weights=weights, metric=metric
         )
         results.append(
             LocalizationResult(

--- a/src/maimonedes/monitor/metric.py
+++ b/src/maimonedes/monitor/metric.py
@@ -1,0 +1,657 @@
+"""Phase 5 Riemannian metric learner: MLP on Phase-2 Jacobians.
+
+Implements a small feed-forward network that maps a compliance-space
+coordinate c ∈ ℝ^k to the lower-triangular Cholesky factor L(c) of
+the local metric tensor g(c) = L(c) L(c)^T (positive-definite by
+construction). Trained on per-anchor empirical Jacobians from
+`monitor/fragility.py`, where each anchor contributes the target
+`g_target = J^T J / ‖J‖²` (Fisher-information style construction).
+
+Implementation choice: PyTorch is not a project dependency. The MLP
+uses pure-numpy forward + backward passes plus a tiny Adam optimizer.
+Persistence is `numpy.savez_compressed` to `.npz` (the issue spec
+mentions `.pt` but our model is numpy-native — same role, different
+wire format).
+
+`riemannian_distance(metric, c0, c1, *, n_segments)` integrates the
+local metric along a straight-line path in coordinate space:
+    d ≈ Σ_i √((Δc_i)^T g(c_mid_i) (Δc_i))
+This captures the §4.6 amplification factors without solving the
+geodesic ODE; v2 can swap in a true geodesic.
+
+Opt-in integration with monitors: every drift / boundary detector
+takes an optional `metric` kwarg; default `None` keeps the current
+Euclidean behaviour.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from maimonedes.core.policy import Policy
+from maimonedes.monitor.fragility import AGGREGATE_COLUMN, Jacobian, all_jacobians
+
+
+# ---------------------------------------------------------------------------
+# Cholesky parameterisation
+# ---------------------------------------------------------------------------
+
+def _tri_param_count(k: int) -> int:
+    """Number of free entries in a k×k lower-triangular matrix (incl. diag)."""
+    return k * (k + 1) // 2
+
+
+def _build_lower_triangular(params: np.ndarray, k: int) -> np.ndarray:
+    """Pack `k(k+1)/2` raw params into a lower-triangular L with positive diag.
+
+    Diagonal entries `L_ii` are exponentiated so g = L L^T is strictly
+    positive-definite for any finite raw param vector. Off-diagonal
+    entries are passed through unchanged. Layout (k=3 example):
+
+        params = [d0, d1, d2, o10, o20, o21]
+        L      = [[exp(d0), 0,        0      ],
+                  [o10,     exp(d1),  0      ],
+                  [o20,     o21,      exp(d2)]]
+    """
+    if params.shape[-1] != _tri_param_count(k):
+        raise ValueError(
+            f"params shape {params.shape} incompatible with k={k}"
+        )
+    L = np.zeros((k, k), dtype=np.float64)
+    # Diagonals first (k entries), then off-diagonals row-major below the diag.
+    for i in range(k):
+        L[i, i] = np.exp(params[i])
+    idx = k
+    for i in range(1, k):
+        for j in range(i):
+            L[i, j] = params[idx]
+            idx += 1
+    return L
+
+
+def _build_lower_triangular_grad(
+    dL: np.ndarray, params: np.ndarray, k: int
+) -> np.ndarray:
+    """Backprop ∂loss/∂params from ∂loss/∂L (k×k, lower-tri only).
+
+    Mirror of `_build_lower_triangular`: diagonals propagate via the
+    chain rule for `L_ii = exp(raw_i)`, off-diagonals are identity.
+    """
+    out = np.zeros(_tri_param_count(k), dtype=np.float64)
+    for i in range(k):
+        # L_ii = exp(params[i]) → dL_ii/dparam_i = L_ii itself.
+        out[i] = dL[i, i] * np.exp(params[i])
+    idx = k
+    for i in range(1, k):
+        for j in range(i):
+            out[idx] = dL[i, j]
+            idx += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Numpy MLP
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MetricMLP:
+    """Numpy MLP `c → L_params ∈ ℝ^{k(k+1)/2}` with `depth` ReLU layers.
+
+    `weights` is a list of (W, b) tuples, one per layer including the
+    output. `forward` returns the raw param vector; `metric_at` uses
+    `_build_lower_triangular` to construct `L` and then `g = L L^T`.
+    """
+
+    k: int
+    hidden: int
+    depth: int
+    weights: list[tuple[np.ndarray, np.ndarray]]
+
+    @classmethod
+    def init(
+        cls,
+        k: int,
+        *,
+        hidden: int = 32,
+        depth: int = 2,
+        seed: int = 0,
+    ) -> "MetricMLP":
+        if depth < 1:
+            raise ValueError(f"depth must be >= 1, got {depth}")
+        rng = np.random.default_rng(seed)
+        weights: list[tuple[np.ndarray, np.ndarray]] = []
+        prev_dim = k
+        out_dim = _tri_param_count(k)
+        for layer in range(depth):
+            # He initialisation for ReLU.
+            scale = np.sqrt(2.0 / max(prev_dim, 1))
+            W = rng.standard_normal((hidden, prev_dim)) * scale
+            b = np.zeros(hidden)
+            weights.append((W, b))
+            prev_dim = hidden
+        # Output layer maps to the Cholesky parameters; small init keeps
+        # the initial metric near identity (L_ii = exp(0) = 1).
+        scale_out = np.sqrt(1.0 / max(prev_dim, 1))
+        W_out = rng.standard_normal((out_dim, prev_dim)) * scale_out * 0.1
+        b_out = np.zeros(out_dim)
+        weights.append((W_out, b_out))
+        return cls(k=k, hidden=hidden, depth=depth, weights=weights)
+
+    def forward(self, c: np.ndarray) -> tuple[np.ndarray, list[np.ndarray]]:
+        """Compute L_params for one `c` vector; cache activations for backward."""
+        a = np.asarray(c, dtype=np.float64).reshape(-1)
+        if a.size != self.k:
+            raise ValueError(f"c shape {a.shape}; expected ({self.k},)")
+        activations: list[np.ndarray] = [a]
+        for layer_idx, (W, b) in enumerate(self.weights):
+            z = W @ a + b
+            if layer_idx < self.depth:
+                a = np.maximum(0.0, z)  # ReLU on hidden layers
+            else:
+                a = z  # linear output (Cholesky raw params)
+            activations.append(a)
+        return activations[-1], activations
+
+    def predict_L(self, c: np.ndarray) -> np.ndarray:
+        params, _ = self.forward(c)
+        return _build_lower_triangular(params, self.k)
+
+    def predict_g(self, c: np.ndarray) -> np.ndarray:
+        L = self.predict_L(c)
+        return L @ L.T
+
+    # ---- backprop helpers --------------------------------------------------
+
+    def backward(
+        self,
+        activations: list[np.ndarray],
+        grad_params: np.ndarray,
+    ) -> list[tuple[np.ndarray, np.ndarray]]:
+        """Backprop ∂loss/∂params through the MLP; returns matching grad shapes.
+
+        `grad_params` is `∂loss/∂(output L_params)`, shape `(k(k+1)/2,)`.
+        `activations[i]` is the input to layer `i` (= output of layer
+        `i-1`); `activations[i+1]` is the output of layer `i`. Hidden
+        layers used ReLU, the output layer is linear.
+        """
+        grads: list[tuple[np.ndarray, np.ndarray]] = [None] * len(self.weights)  # type: ignore[list-item]
+        delta = grad_params  # ∂loss/∂(output of current layer)
+        for layer_idx in reversed(range(len(self.weights))):
+            W, _ = self.weights[layer_idx]
+            is_hidden = layer_idx < self.depth
+            if is_hidden:
+                # delta currently is ∂L/∂a[layer_idx]; multiply by ReLU'
+                # to get ∂L/∂z[layer_idx]. ReLU(z) > 0 ⇔ z > 0.
+                a_out = activations[layer_idx + 1]
+                delta = delta * (a_out > 0).astype(np.float64)
+            a_in = activations[layer_idx]
+            grad_W = np.outer(delta, a_in)
+            grad_b = delta.copy()
+            grads[layer_idx] = (grad_W, grad_b)
+            if layer_idx > 0:
+                delta = W.T @ delta  # ∂L/∂a[layer_idx-1]
+        return grads
+
+
+# ---------------------------------------------------------------------------
+# Adam optimizer (stateful tiny helper)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _AdamState:
+    m: list[tuple[np.ndarray, np.ndarray]]
+    v: list[tuple[np.ndarray, np.ndarray]]
+    t: int = 0
+
+    @classmethod
+    def for_mlp(cls, mlp: MetricMLP) -> "_AdamState":
+        m = [(np.zeros_like(W), np.zeros_like(b)) for (W, b) in mlp.weights]
+        v = [(np.zeros_like(W), np.zeros_like(b)) for (W, b) in mlp.weights]
+        return cls(m=m, v=v)
+
+
+def _adam_step(
+    mlp: MetricMLP,
+    grads: list[tuple[np.ndarray, np.ndarray]],
+    state: _AdamState,
+    *,
+    lr: float = 1e-2,
+    beta1: float = 0.9,
+    beta2: float = 0.999,
+    eps: float = 1e-8,
+) -> None:
+    state.t += 1
+    bc1 = 1.0 - beta1 ** state.t
+    bc2 = 1.0 - beta2 ** state.t
+    new_weights: list[tuple[np.ndarray, np.ndarray]] = []
+    for layer_idx, ((W, b), (gW, gb)) in enumerate(zip(mlp.weights, grads)):
+        mW, mb = state.m[layer_idx]
+        vW, vb = state.v[layer_idx]
+        mW_new = beta1 * mW + (1.0 - beta1) * gW
+        mb_new = beta1 * mb + (1.0 - beta1) * gb
+        vW_new = beta2 * vW + (1.0 - beta2) * (gW * gW)
+        vb_new = beta2 * vb + (1.0 - beta2) * (gb * gb)
+        state.m[layer_idx] = (mW_new, mb_new)
+        state.v[layer_idx] = (vW_new, vb_new)
+        W_new = W - lr * (mW_new / bc1) / (np.sqrt(vW_new / bc2) + eps)
+        b_new = b - lr * (mb_new / bc1) / (np.sqrt(vb_new / bc2) + eps)
+        new_weights.append((W_new, b_new))
+    mlp.weights = new_weights
+
+
+# ---------------------------------------------------------------------------
+# RiemannianMetric dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RiemannianMetric:
+    """Trained metric: holds the MLP + provenance metadata.
+
+    The `model` field is the numpy `MetricMLP` (not a `torch.nn.Module`
+    despite the issue spec's wording — see module docstring). `path`
+    is set after `save(...)` and on `load(...)`.
+    """
+
+    model: MetricMLP
+    policy_id: str
+    trained_at: datetime
+    n_anchors: int
+    n_jacobians: int
+    eval_metrics: dict[str, float]
+    path: Path | None = None
+    sub_condition_ids: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def k(self) -> int:
+        return self.model.k
+
+    # ------------- persistence -------------
+
+    def save(self, path: Path) -> "RiemannianMetric":
+        """Write to `.npz`. Returns self with `path` populated."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Pack weights into a flat dict of named arrays.
+        data: dict[str, Any] = {
+            "k": np.asarray(self.model.k),
+            "hidden": np.asarray(self.model.hidden),
+            "depth": np.asarray(self.model.depth),
+            "policy_id": np.asarray(self.policy_id),
+            "trained_at": np.asarray(self.trained_at.isoformat()),
+            "n_anchors": np.asarray(self.n_anchors),
+            "n_jacobians": np.asarray(self.n_jacobians),
+            "eval_metrics_json": np.asarray(
+                json.dumps(self.eval_metrics, sort_keys=True)
+            ),
+            "sub_condition_ids_json": np.asarray(
+                json.dumps(list(self.sub_condition_ids))
+            ),
+        }
+        for layer_idx, (W, b) in enumerate(self.model.weights):
+            data[f"W{layer_idx}"] = W
+            data[f"b{layer_idx}"] = b
+        np.savez_compressed(path, **data)
+        self.path = path
+        return self
+
+    @classmethod
+    def load(cls, path: Path) -> "RiemannianMetric":
+        path = Path(path)
+        with np.load(path, allow_pickle=False) as f:
+            k = int(f["k"])
+            hidden = int(f["hidden"])
+            depth = int(f["depth"])
+            policy_id = str(f["policy_id"])
+            trained_at = datetime.fromisoformat(str(f["trained_at"]))
+            n_anchors = int(f["n_anchors"])
+            n_jacobians = int(f["n_jacobians"])
+            eval_metrics = json.loads(str(f["eval_metrics_json"]))
+            try:
+                sub_ids_raw = json.loads(str(f["sub_condition_ids_json"]))
+                sub_condition_ids = tuple(sub_ids_raw)
+            except Exception:
+                sub_condition_ids = tuple()
+            n_layers = depth + 1  # hidden layers + output
+            weights: list[tuple[np.ndarray, np.ndarray]] = []
+            for layer_idx in range(n_layers):
+                weights.append((f[f"W{layer_idx}"].copy(), f[f"b{layer_idx}"].copy()))
+        mlp = MetricMLP(k=k, hidden=hidden, depth=depth, weights=weights)
+        return cls(
+            model=mlp,
+            policy_id=policy_id,
+            trained_at=trained_at,
+            n_anchors=n_anchors,
+            n_jacobians=n_jacobians,
+            eval_metrics=eval_metrics,
+            path=path,
+            sub_condition_ids=sub_condition_ids,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Loss + training loop
+# ---------------------------------------------------------------------------
+
+def _frobenius_loss_and_grad(
+    L: np.ndarray, g_target: np.ndarray
+) -> tuple[float, np.ndarray]:
+    """Loss = ‖L L^T - g_target‖_F²; returns scalar loss + ∂loss/∂L (k×k).
+
+    For symmetric `g_target`, `diff = L L^T - g_target` is symmetric and
+    ∂‖diff‖_F²/∂L = 4 · diff @ L  (since g = L L^T, see issue's
+    Cholesky-output backprop note).
+    """
+    g_pred = L @ L.T
+    diff = g_pred - g_target
+    loss = float(np.sum(diff * diff))
+    grad_L = 4.0 * (diff @ L)
+    return loss, grad_L
+
+
+def _l2_penalty(mlp: MetricMLP) -> tuple[float, list[tuple[np.ndarray, np.ndarray]]]:
+    """L2 norm of all weights + matching gradient (biases excluded by convention)."""
+    penalty = 0.0
+    grads: list[tuple[np.ndarray, np.ndarray]] = []
+    for (W, b) in mlp.weights:
+        penalty += float(np.sum(W * W))
+        grads.append((2.0 * W, np.zeros_like(b)))
+    return penalty, grads
+
+
+def fit_metric_from_pairs(
+    c_array: np.ndarray,
+    g_array: np.ndarray,
+    *,
+    k: int,
+    hidden: int = 32,
+    depth: int = 2,
+    epochs: int = 200,
+    l2: float = 1e-3,
+    lr: float = 1e-2,
+    seed: int = 0,
+    val_fraction: float = 0.2,
+    policy_id: str = "<unknown>",
+    n_anchors: int = 0,
+    n_jacobians: int = 0,
+    sub_condition_ids: tuple[str, ...] = (),
+) -> RiemannianMetric:
+    """Fit `MetricMLP` to (c_i, g_i) pairs.
+
+    Splits inputs into train / val by `val_fraction` (deterministic
+    via `seed`). Reports `train_loss`, `val_loss` in the returned
+    `RiemannianMetric.eval_metrics`. With < 5 samples the val split
+    collapses to the full train set (val_loss == train_loss).
+    """
+    c_array = np.asarray(c_array, dtype=np.float64)
+    g_array = np.asarray(g_array, dtype=np.float64)
+    if c_array.shape[1] != k:
+        raise ValueError(f"c_array width {c_array.shape[1]}; expected k={k}")
+    if g_array.shape[1:] != (k, k):
+        raise ValueError(f"g_array shape {g_array.shape}; expected (n, {k}, {k})")
+    n_samples = c_array.shape[0]
+    if n_samples == 0:
+        raise ValueError("fit_metric_from_pairs: zero training pairs")
+
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(n_samples)
+    if n_samples >= 5:
+        n_val = max(1, int(round(n_samples * val_fraction)))
+        val_idx = perm[:n_val]
+        train_idx = perm[n_val:]
+    else:
+        val_idx = perm
+        train_idx = perm
+
+    mlp = MetricMLP.init(k=k, hidden=hidden, depth=depth, seed=seed)
+    state = _AdamState.for_mlp(mlp)
+
+    def _epoch_loss(indices: np.ndarray) -> float:
+        if len(indices) == 0:
+            return 0.0
+        total = 0.0
+        for i in indices:
+            params, _ = mlp.forward(c_array[i])
+            L = _build_lower_triangular(params, k)
+            loss, _ = _frobenius_loss_and_grad(L, g_array[i])
+            total += loss
+        return total / len(indices)
+
+    train_idx_local = list(train_idx)
+    final_train_loss = float("inf")
+    final_val_loss = float("inf")
+    for epoch in range(epochs):
+        rng.shuffle(train_idx_local)
+        epoch_loss = 0.0
+        for i in train_idx_local:
+            params, activations = mlp.forward(c_array[i])
+            L = _build_lower_triangular(params, k)
+            loss, dL = _frobenius_loss_and_grad(L, g_array[i])
+            epoch_loss += loss
+            grad_params = _build_lower_triangular_grad(dL, params, k)
+            grads = mlp.backward(activations, grad_params)
+            if l2 > 0.0:
+                # L2 regularisation gradient (no per-sample averaging).
+                _, l2_grads = _l2_penalty(mlp)
+                grads = [
+                    (gW + l2 * lW, gb + l2 * lb)
+                    for (gW, gb), (lW, lb) in zip(grads, l2_grads)
+                ]
+            _adam_step(mlp, grads, state, lr=lr)
+        final_train_loss = epoch_loss / max(len(train_idx_local), 1)
+        final_val_loss = _epoch_loss(val_idx)
+
+    return RiemannianMetric(
+        model=mlp,
+        policy_id=policy_id,
+        trained_at=datetime.now(timezone.utc),
+        n_anchors=n_anchors,
+        n_jacobians=n_jacobians,
+        eval_metrics={
+            "train_loss": float(final_train_loss),
+            "val_loss": float(final_val_loss),
+        },
+        sub_condition_ids=sub_condition_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor pair extraction
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _AnchorPair:
+    anchor_id: str
+    c: np.ndarray
+    g_target: np.ndarray
+    n_perturbations: int
+
+
+def _columns_for_axes(jac: Jacobian) -> list[str]:
+    return [c for c in jac.columns if c != AGGREGATE_COLUMN]
+
+
+def _anchor_pair_from_jacobian(jac: Jacobian) -> _AnchorPair | None:
+    """Build (c_anchor, g_target) for one anchor's Jacobian, or None.
+
+    `c_anchor` is the per-axis baseline; `g_target = J^T J / ‖J‖²` over
+    the rows in the Jacobian, where each row's per-axis Δ becomes one
+    row of J. Returns None when the anchor has zero perturbation rows.
+    """
+    axes = _columns_for_axes(jac)
+    if not axes:
+        return None
+    c = np.asarray(
+        [jac.baseline_per_sub_condition.get(a, 0.0) for a in axes],
+        dtype=np.float64,
+    )
+    if not jac.rows:
+        return None
+    J = np.zeros((len(jac.rows), len(axes)), dtype=np.float64)
+    for i, row in enumerate(jac.rows):
+        for j, a in enumerate(axes):
+            J[i, j] = row.deltas.get(a, 0.0)
+    norm_sq = float(np.sum(J * J))
+    if norm_sq <= 1e-12:
+        # Anchor is fully insensitive to its perturbation cloud → metric
+        # is undefined here. Skip with a small ridge to keep training
+        # stable on sister anchors.
+        return None
+    g_target = (J.T @ J) / norm_sq
+    return _AnchorPair(
+        anchor_id=jac.anchor_id,
+        c=c,
+        g_target=g_target,
+        n_perturbations=len(jac.rows),
+    )
+
+
+def _collect_anchor_pairs(policy: Policy) -> list[_AnchorPair]:
+    """Build training pairs for every anchor with a usable Jacobian."""
+    expected_axes = [s.id for s in policy.rubric.sub_conditions]
+    out: list[_AnchorPair] = []
+    for anchor_id, jac in all_jacobians().items():
+        # Filter to anchors whose Jacobian columns line up with the
+        # current rubric — drift between policy versions would
+        # otherwise sneak in stale axes.
+        axes = _columns_for_axes(jac)
+        if set(axes) != set(expected_axes):
+            continue
+        # Re-order to the policy's canonical axis order so every
+        # anchor's c-vector lives in the same coordinate system.
+        c_dict = jac.baseline_per_sub_condition
+        c = np.asarray(
+            [c_dict.get(a, 0.0) for a in expected_axes],
+            dtype=np.float64,
+        )
+        J = np.zeros((len(jac.rows), len(expected_axes)), dtype=np.float64)
+        for i, row in enumerate(jac.rows):
+            for j, a in enumerate(expected_axes):
+                J[i, j] = row.deltas.get(a, 0.0)
+        norm_sq = float(np.sum(J * J))
+        if norm_sq <= 1e-12 or not jac.rows:
+            continue
+        g_target = (J.T @ J) / norm_sq
+        out.append(
+            _AnchorPair(
+                anchor_id=anchor_id,
+                c=c,
+                g_target=g_target,
+                n_perturbations=len(jac.rows),
+            )
+        )
+    return out
+
+
+def fit_metric(
+    *,
+    policy: Policy,
+    hidden: int = 32,
+    depth: int = 2,
+    l2: float = 1e-3,
+    epochs: int = 200,
+    lr: float = 1e-2,
+    seed: int = 0,
+) -> RiemannianMetric:
+    """Pull anchor Jacobians from the DB and fit a `RiemannianMetric`.
+
+    Raises `ValueError` when no anchors have usable Jacobians (e.g.,
+    `maimonedes perturb` has not been run yet).
+    """
+    pairs = _collect_anchor_pairs(policy)
+    if not pairs:
+        raise ValueError(
+            "fit_metric: no anchor Jacobians found; run `maimonedes perturb` first"
+        )
+    expected_axes = tuple(s.id for s in policy.rubric.sub_conditions)
+    k = len(expected_axes)
+    c_array = np.stack([p.c for p in pairs], axis=0)
+    g_array = np.stack([p.g_target for p in pairs], axis=0)
+    n_jacobians = sum(p.n_perturbations for p in pairs)
+    return fit_metric_from_pairs(
+        c_array,
+        g_array,
+        k=k,
+        hidden=hidden,
+        depth=depth,
+        epochs=epochs,
+        l2=l2,
+        lr=lr,
+        seed=seed,
+        policy_id=policy.id,
+        n_anchors=len(pairs),
+        n_jacobians=n_jacobians,
+        sub_condition_ids=expected_axes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public read-side API
+# ---------------------------------------------------------------------------
+
+def metric_at(metric: RiemannianMetric, c: np.ndarray) -> np.ndarray:
+    """Local metric tensor `g(c) ∈ ℝ^{k×k}` (positive-definite)."""
+    return metric.model.predict_g(np.asarray(c, dtype=np.float64))
+
+
+def riemannian_distance(
+    metric: RiemannianMetric,
+    c0: np.ndarray,
+    c1: np.ndarray,
+    *,
+    n_segments: int = 16,
+) -> float:
+    """Piecewise-linear Riemannian distance from c0 to c1.
+
+    For each of `n_segments` equal sub-intervals of the straight-line
+    coordinate path, integrates `√((Δc)^T g(c_mid) (Δc))` and sums.
+    The path stays straight in coordinate space — geodesic-ODE solving
+    is deferred to v2 (issue's "implementation notes").
+    """
+    if n_segments < 1:
+        raise ValueError("n_segments must be >= 1")
+    c0_arr = np.asarray(c0, dtype=np.float64)
+    c1_arr = np.asarray(c1, dtype=np.float64)
+    if c0_arr.shape != c1_arr.shape:
+        raise ValueError(f"c0 shape {c0_arr.shape} != c1 shape {c1_arr.shape}")
+    if c0_arr.ndim != 1 or c0_arr.size != metric.k:
+        raise ValueError(f"c0/c1 must be ({metric.k},) vectors")
+    delta_total = c1_arr - c0_arr
+    seg_delta = delta_total / n_segments
+    total = 0.0
+    for i in range(n_segments):
+        t_mid = (i + 0.5) / n_segments
+        c_mid = c0_arr + t_mid * delta_total
+        g_mid = metric_at(metric, c_mid)
+        quad = float(seg_delta @ g_mid @ seg_delta)
+        # Numerical floor — quad should be >= 0 for PD g, but tiny
+        # negative values can appear from rounding.
+        total += np.sqrt(max(quad, 0.0))
+    return total
+
+
+def euclidean_distance(c0: np.ndarray, c1: np.ndarray) -> float:
+    """Plain L2 distance — convenience for side-by-side reporting."""
+    return float(np.linalg.norm(np.asarray(c1) - np.asarray(c0)))
+
+
+def position_vector(score_per_sub: dict[str, float], axes: Iterable[str]) -> np.ndarray:
+    """Project a `per_sub_condition` dict onto a fixed axis order."""
+    return np.asarray([score_per_sub.get(a, 0.0) for a in axes], dtype=np.float64)
+
+
+__all__ = [
+    "MetricMLP",
+    "RiemannianMetric",
+    "euclidean_distance",
+    "fit_metric",
+    "fit_metric_from_pairs",
+    "metric_at",
+    "position_vector",
+    "riemannian_distance",
+]

--- a/src/maimonedes/storage/__init__.py
+++ b/src/maimonedes/storage/__init__.py
@@ -9,6 +9,7 @@ from maimonedes.storage import (  # noqa: F401
     compliance,
     drift,
     llm_calls,
+    metric_fits,
     models,
     perturbations,
     recovery,

--- a/src/maimonedes/storage/__init__.py
+++ b/src/maimonedes/storage/__init__.py
@@ -13,4 +13,5 @@ from maimonedes.storage import (  # noqa: F401
     models,
     perturbations,
     recovery,
+    structural_signals,
 )

--- a/src/maimonedes/storage/metric_fits.py
+++ b/src/maimonedes/storage/metric_fits.py
@@ -1,0 +1,132 @@
+"""ORM mapping + repository helpers for Riemannian metric fits.
+
+A `metric_fit` row records one trained metric — the on-disk path of
+the `.npz` model file plus enough provenance (policy_id, n_anchors,
+n_jacobians, val_loss) to pick the right metric for a CLI command
+without re-fitting. Mirrors the shape of `recovery_runs` (a record
+of a fit/run + a pointer to its artefacts).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Float, Integer, String, Text, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from maimonedes.storage.models import Base
+from maimonedes.storage.repo import get_session
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class MetricFitRow(Base):
+    __tablename__ = "metric_fits"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    policy_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    trained_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    n_anchors: Mapped[int] = mapped_column(Integer, nullable=False)
+    n_jacobians: Mapped[int] = mapped_column(Integer, nullable=False)
+    val_loss: Mapped[float | None] = mapped_column(Float, nullable=True)
+    train_loss: Mapped[float | None] = mapped_column(Float, nullable=True)
+    hyperparams_json: Mapped[str] = mapped_column(
+        Text, nullable=False, default="{}"
+    )
+
+
+def _row_to_dict(row: MetricFitRow) -> dict[str, object]:
+    trained = row.trained_at
+    if trained.tzinfo is None:
+        trained = trained.replace(tzinfo=timezone.utc)
+    try:
+        hp = json.loads(row.hyperparams_json)
+    except json.JSONDecodeError:
+        hp = {}
+    return {
+        "id": row.id,
+        "policy_id": row.policy_id,
+        "path": row.path,
+        "trained_at": trained,
+        "n_anchors": row.n_anchors,
+        "n_jacobians": row.n_jacobians,
+        "val_loss": row.val_loss,
+        "train_loss": row.train_loss,
+        "hyperparams": hp,
+    }
+
+
+def record_metric_fit(
+    *,
+    policy_id: str,
+    path: str,
+    n_anchors: int,
+    n_jacobians: int,
+    val_loss: float | None,
+    train_loss: float | None,
+    hyperparams: dict[str, object] | None = None,
+) -> int:
+    """Insert a `metric_fit` row and return its id."""
+    payload = json.dumps(hyperparams or {}, sort_keys=True, default=str)
+    with get_session() as session:
+        row = MetricFitRow(
+            policy_id=policy_id,
+            path=path,
+            n_anchors=n_anchors,
+            n_jacobians=n_jacobians,
+            val_loss=val_loss,
+            train_loss=train_loss,
+            hyperparams_json=payload,
+        )
+        session.add(row)
+        session.flush()
+        return row.id
+
+
+def get_metric_fit(fit_id: int) -> dict[str, object] | None:
+    with get_session() as session:
+        row = session.get(MetricFitRow, fit_id)
+        return _row_to_dict(row) if row is not None else None
+
+
+def latest_metric_fit_for_policy(policy_id: str) -> dict[str, object] | None:
+    """Return the newest fit for `policy_id`, or None if none exist."""
+    with get_session() as session:
+        row = session.execute(
+            select(MetricFitRow)
+            .where(MetricFitRow.policy_id == policy_id)
+            .order_by(
+                MetricFitRow.trained_at.desc(),
+                MetricFitRow.id.desc(),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        return _row_to_dict(row) if row is not None else None
+
+
+def list_metric_fits(
+    policy_id: str | None = None, *, limit: int = 50
+) -> list[dict[str, object]]:
+    """Most-recent first; optionally scoped to a policy."""
+    with get_session() as session:
+        stmt = select(MetricFitRow).order_by(
+            MetricFitRow.trained_at.desc(), MetricFitRow.id.desc()
+        ).limit(limit)
+        if policy_id is not None:
+            stmt = stmt.where(MetricFitRow.policy_id == policy_id)
+        rows = session.execute(stmt).scalars().all()
+        return [_row_to_dict(r) for r in rows]
+
+
+__all__ = [
+    "MetricFitRow",
+    "get_metric_fit",
+    "latest_metric_fit_for_policy",
+    "list_metric_fits",
+    "record_metric_fit",
+]

--- a/src/maimonedes/storage/structural_signals.py
+++ b/src/maimonedes/storage/structural_signals.py
@@ -1,0 +1,143 @@
+"""ORM mapping + repository helpers for structural alert signals (issue #51).
+
+A `structural_signal` row is one fired alert from the decoupling or
+curvature detectors. The schema is intentionally narrow — `signal_type`
+discriminates the two flavours, `metric_value` stores the scalar
+above `threshold`, and `evidence_json` carries the per-detector blob
+that explains why the alert fired (flipped covariance pairs,
+condition-number ratio, etc.).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    DateTime,
+    Float,
+    Integer,
+    String,
+    Text,
+    select,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from maimonedes.storage.models import Base
+from maimonedes.storage.repo import get_session
+
+
+SIGNAL_TYPES = ("decoupling", "curvature")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class StructuralSignalRow(Base):
+    __tablename__ = "structural_signals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    anchor_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    signal_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    metric_value: Mapped[float] = mapped_column(Float, nullable=False)
+    threshold: Mapped[float] = mapped_column(Float, nullable=False)
+    fired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    evidence_json: Mapped[str] = mapped_column(
+        Text, nullable=False, default="{}"
+    )
+
+
+def _row_to_dict(row: StructuralSignalRow) -> dict[str, object]:
+    fired = row.fired_at
+    if fired.tzinfo is None:
+        fired = fired.replace(tzinfo=timezone.utc)
+    try:
+        evidence = json.loads(row.evidence_json)
+    except json.JSONDecodeError:
+        evidence = {}
+    return {
+        "id": row.id,
+        "anchor_id": row.anchor_id,
+        "signal_type": row.signal_type,
+        "metric_value": row.metric_value,
+        "threshold": row.threshold,
+        "fired_at": fired,
+        "evidence": evidence,
+    }
+
+
+def record_structural_signal(
+    *,
+    anchor_id: str,
+    signal_type: str,
+    metric_value: float,
+    threshold: float,
+    evidence: dict[str, object] | None = None,
+) -> int:
+    """Insert one fired signal; raises on unknown signal_type values."""
+    if signal_type not in SIGNAL_TYPES:
+        raise ValueError(
+            f"unknown signal_type {signal_type!r}; expected one of {SIGNAL_TYPES}"
+        )
+    payload = json.dumps(evidence or {}, sort_keys=True, default=str)
+    with get_session() as session:
+        row = StructuralSignalRow(
+            anchor_id=anchor_id,
+            signal_type=signal_type,
+            metric_value=metric_value,
+            threshold=threshold,
+            evidence_json=payload,
+        )
+        session.add(row)
+        session.flush()
+        return row.id
+
+
+def signals_for_anchor(
+    anchor_id: str, *, signal_type: str | None = None, limit: int = 50
+) -> list[dict[str, object]]:
+    """Most-recent first; optionally filter by signal_type."""
+    with get_session() as session:
+        stmt = (
+            select(StructuralSignalRow)
+            .where(StructuralSignalRow.anchor_id == anchor_id)
+            .order_by(
+                StructuralSignalRow.fired_at.desc(),
+                StructuralSignalRow.id.desc(),
+            )
+            .limit(limit)
+        )
+        if signal_type is not None:
+            stmt = stmt.where(StructuralSignalRow.signal_type == signal_type)
+        rows = session.execute(stmt).scalars().all()
+        return [_row_to_dict(r) for r in rows]
+
+
+def list_structural_signals(
+    *, signal_type: str | None = None, limit: int = 100
+) -> list[dict[str, object]]:
+    """Cross-anchor signal feed — useful for the dashboard timeline."""
+    with get_session() as session:
+        stmt = (
+            select(StructuralSignalRow)
+            .order_by(
+                StructuralSignalRow.fired_at.desc(),
+                StructuralSignalRow.id.desc(),
+            )
+            .limit(limit)
+        )
+        if signal_type is not None:
+            stmt = stmt.where(StructuralSignalRow.signal_type == signal_type)
+        rows = session.execute(stmt).scalars().all()
+        return [_row_to_dict(r) for r in rows]
+
+
+__all__ = [
+    "SIGNAL_TYPES",
+    "StructuralSignalRow",
+    "list_structural_signals",
+    "record_structural_signal",
+    "signals_for_anchor",
+]

--- a/tests/test_curvature.py
+++ b/tests/test_curvature.py
@@ -1,0 +1,148 @@
+"""Tests for the curvature signal (issue #51)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from maimonedes.monitor.curvature import (
+    CurvatureResult,
+    compute_curvature,
+    curvature_drift,
+    curvature_per_anchor,
+)
+from maimonedes.monitor.metric import (
+    MetricMLP,
+    RiemannianMetric,
+    fit_metric_from_pairs,
+)
+
+
+def _metric_with_constant_g(g_const: np.ndarray) -> RiemannianMetric:
+    """Fit a tiny MLP to a constant `g_const` everywhere.
+
+    With repeated training pairs across a small grid the MLP collapses
+    onto the constant; close enough for curvature comparisons.
+    `c_arr` width matches `g_const`'s dimensionality so the API
+    contract on `k` is satisfied.
+    """
+    k = g_const.shape[0]
+    rng = np.random.default_rng(0)
+    c_arr = rng.uniform(0.0, 1.0, size=(16, k))
+    g_arr = np.tile(g_const[None, :, :], (16, 1, 1))
+    return fit_metric_from_pairs(
+        c_arr,
+        g_arr,
+        k=k,
+        hidden=8,
+        depth=1,
+        epochs=600,
+        lr=0.05,
+        seed=0,
+        policy_id="curv",
+    )
+
+
+def test_compute_curvature_eigenvalue_ratio() -> None:
+    """A diagonal `g = diag(λ_max, λ_min)` returns `λ_max / λ_min`."""
+    g = np.diag([4.0, 1.0])
+    metric = _metric_with_constant_g(g)
+    kappa = compute_curvature(metric, np.array([0.5, 0.5]))
+    # Allow some tolerance; the MLP fit isn't exact.
+    assert kappa == pytest.approx(4.0, abs=0.5)
+
+
+def test_compute_curvature_isotropic_metric_is_one() -> None:
+    """`g = c · I` has condition number 1 regardless of scale."""
+    metric = _metric_with_constant_g(np.eye(2) * 2.5)
+    kappa = compute_curvature(metric, np.array([0.5, 0.5]))
+    assert kappa == pytest.approx(1.0, abs=0.2)
+
+
+def test_curvature_drift_fires_on_anisotropic_increase() -> None:
+    """Isotropic baseline + anisotropic current → fires on relative increase."""
+    metric_baseline = _metric_with_constant_g(np.eye(2) * 1.0)  # κ = 1
+    metric_current = _metric_with_constant_g(np.diag([10.0, 1.0]))  # κ = 10
+
+    res = curvature_drift(
+        anchor_id="A1",
+        metric_baseline=metric_baseline,
+        metric_current=metric_current,
+        c=np.array([0.5, 0.5]),
+    )
+    assert res.signal_fired is True
+    assert res.relative_increase > 1.0
+
+
+def test_curvature_drift_does_not_fire_when_metrics_match() -> None:
+    """Two metrics fit to the same data should not register a drift."""
+    g = np.diag([2.0, 1.0])
+    metric_a = _metric_with_constant_g(g)
+    # Re-fit with a different seed so weights differ but g is similar.
+    c_arr = np.array([[0.5, 0.5]] * 8)
+    g_arr = np.tile(g[None, :, :], (8, 1, 1))
+    metric_b = fit_metric_from_pairs(
+        c_arr, g_arr, k=2, hidden=8, depth=1, epochs=600, lr=0.05, seed=1, policy_id="b"
+    )
+    res = curvature_drift(
+        anchor_id="A1",
+        metric_baseline=metric_a,
+        metric_current=metric_b,
+        c=np.array([0.5, 0.5]),
+    )
+    # Both have κ ≈ 2.0; relative increase should be small.
+    assert res.signal_fired is False
+    assert abs(res.relative_increase) < 0.3
+
+
+def test_curvature_drift_threshold_override() -> None:
+    metric_baseline = _metric_with_constant_g(np.diag([2.0, 1.0]))  # κ ≈ 2
+    metric_current = _metric_with_constant_g(np.diag([3.0, 1.0]))  # κ ≈ 3 → +50%
+
+    # Default h=0.5 puts +50% right at the boundary; tightening to
+    # 0.2 forces a fire, loosening to 1.0 suppresses it.
+    fire_loose = curvature_drift(
+        anchor_id="A1",
+        metric_baseline=metric_baseline,
+        metric_current=metric_current,
+        c=np.array([0.5, 0.5]),
+        h_curvature=0.2,
+    )
+    suppress = curvature_drift(
+        anchor_id="A1",
+        metric_baseline=metric_baseline,
+        metric_current=metric_current,
+        c=np.array([0.5, 0.5]),
+        h_curvature=2.0,
+    )
+    assert fire_loose.signal_fired is True
+    assert suppress.signal_fired is False
+
+
+def test_curvature_drift_raises_on_dimensionality_mismatch() -> None:
+    metric_2d = _metric_with_constant_g(np.eye(2))
+    metric_3d = _metric_with_constant_g(np.eye(3))
+    with pytest.raises(ValueError, match="dimensionality mismatch"):
+        curvature_drift(
+            anchor_id="A1",
+            metric_baseline=metric_2d,
+            metric_current=metric_3d,
+            c=np.array([0.5, 0.5]),
+        )
+
+
+def test_curvature_per_anchor_routes_positions() -> None:
+    metric_baseline = _metric_with_constant_g(np.eye(2))
+    metric_current = _metric_with_constant_g(np.diag([5.0, 1.0]))
+    positions = {
+        "A1": np.array([0.5, 0.5]),
+        "A2": np.array([0.7, 0.3]),
+    }
+    results = curvature_per_anchor(
+        positions,
+        metric_baseline=metric_baseline,
+        metric_current=metric_current,
+    )
+    assert set(results) == {"A1", "A2"}
+    for r in results.values():
+        assert isinstance(r, CurvatureResult)
+        assert r.signal_fired is True

--- a/tests/test_decoupling.py
+++ b/tests/test_decoupling.py
@@ -1,0 +1,313 @@
+"""Tests for the decoupling signal (issue #51).
+
+Covers:
+- Empirical covariance over a synthetic stream.
+- Sign-flip detection: positively correlated → negatively correlated
+  triggers `signal_fired`.
+- False-positive guard: zero off-diagonal change should not fire even
+  when per-axis variance shifts (which is what fragility is for).
+- §4.6 Example 4 reproduction: positional drift = 0, fragility per-axis
+  ≈ 0, but covariance flips → only decoupling fires.
+- structural_signals storage round-trip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from maimonedes.core.compliance import ComplianceScore
+from maimonedes.core.perturbation import PerturbationProbe
+from maimonedes.monitor.decoupling import (
+    DecouplingResult,
+    _empirical_covariance,
+    compute_axis_covariance,
+    decoupling_signal,
+)
+from maimonedes.settings import Settings
+from maimonedes.storage.compliance import record_score
+from maimonedes.storage.perturbations import record_perturbation
+from maimonedes.storage.repo import init_engine, reset_engine_for_tests
+from maimonedes.storage.structural_signals import (
+    list_structural_signals,
+    record_structural_signal,
+    signals_for_anchor,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ALEMBIC_INI = PROJECT_ROOT / "alembic.ini"
+
+AXIS_IDS = ("scope", "calibration")
+
+
+def _alembic_cfg(database_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("script_location", str(PROJECT_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    db_path = tmp_path / "decoupling.sqlite"
+    url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    reset_engine_for_tests()
+    init_engine(Settings(database_url=url))
+    command.upgrade(_alembic_cfg(url), "head")
+    yield url
+    reset_engine_for_tests()
+
+
+def _seed_anchor_baseline(anchor_id: str, vals: tuple[float, ...]) -> None:
+    record_score(
+        ComplianceScore(
+            anchor_id=anchor_id,
+            policy_id="scope_of_practice",
+            per_sub_condition={a: v for a, v in zip(AXIS_IDS, vals)},
+            aggregate=float(sum(vals) / len(vals)),
+            judge_model="judge:test",
+            supervised_model="supervised:test",
+            probe_role="anchor",
+        )
+    )
+
+
+def _seed_perturbation_score(
+    anchor_id: str,
+    transform_label: str,
+    vals: tuple[float, ...],
+) -> int:
+    probe = PerturbationProbe(
+        anchor_id=anchor_id,
+        scenario=f"perturbed by {transform_label}",
+        perturbation_kind="authority",
+        transform_label=transform_label,
+    )
+    row_id = record_perturbation(probe)
+    record_score(
+        ComplianceScore(
+            anchor_id=anchor_id,
+            policy_id="scope_of_practice",
+            per_sub_condition={a: v for a, v in zip(AXIS_IDS, vals)},
+            aggregate=float(sum(vals) / len(vals)),
+            judge_model="judge:test",
+            supervised_model="supervised:test",
+            perturbation_id=row_id,
+            probe_role="perturbation",
+        )
+    )
+    return row_id
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy primitives
+# ---------------------------------------------------------------------------
+
+
+def test_empirical_covariance_matches_numpy_cov() -> None:
+    rng = np.random.default_rng(0)
+    matrix = rng.standard_normal((50, 3))
+    ours = _empirical_covariance(matrix)
+    theirs = np.cov(matrix, rowvar=False, ddof=1)
+    np.testing.assert_allclose(ours, theirs, atol=1e-10)
+
+
+def test_empirical_covariance_returns_zeros_for_lt_two_samples() -> None:
+    out = _empirical_covariance(np.array([[0.5, 0.3]]))
+    assert out.shape == (2, 2)
+    assert np.all(out == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# decoupling_signal: storage-backed
+# ---------------------------------------------------------------------------
+
+
+def _seed_correlated_stream(
+    anchor_id: str,
+    n_baseline: int,
+    n_current: int,
+    *,
+    baseline_corr: float,
+    current_corr: float,
+    seed: int = 0,
+) -> None:
+    """Seed perturbation rows with controlled per-axis correlation.
+
+    Inserts the BASELINE rows first (oldest), then the CURRENT rows
+    (newest) — matching `decoupling_signal`'s newest-first ordering.
+    """
+    rng = np.random.default_rng(seed)
+
+    def _samples(n: int, corr: float) -> np.ndarray:
+        # Two correlated standard normals, scaled into [0,1] band.
+        cov = np.array([[1.0, corr], [corr, 1.0]])
+        L = np.linalg.cholesky(cov)
+        z = rng.standard_normal((n, 2))
+        return 0.6 + 0.1 * (z @ L.T)
+
+    baseline = _samples(n_baseline, baseline_corr)
+    current = _samples(n_current, current_corr)
+    # Oldest first → baseline, then current. SQLite ordering uses
+    # `scored_at desc, id desc`, so insertion order becomes the
+    # newest-last list head.
+    for i, vals in enumerate(baseline):
+        _seed_perturbation_score(anchor_id, f"base_{i}", tuple(float(v) for v in vals))
+    for i, vals in enumerate(current):
+        _seed_perturbation_score(anchor_id, f"cur_{i}", tuple(float(v) for v in vals))
+
+
+def test_decoupling_fires_after_correlation_sign_flip(db: str) -> None:
+    _seed_anchor_baseline("A1", (0.6, 0.6))
+    _seed_correlated_stream(
+        "A1",
+        n_baseline=60,
+        n_current=30,
+        baseline_corr=+0.85,
+        current_corr=-0.85,
+        seed=1,
+    )
+    result = decoupling_signal(
+        anchor_id="A1",
+        axis_ids=AXIS_IDS,
+        baseline_window=60,
+        current_window=30,
+    )
+    assert result.signal_fired is True
+    # The (0, 1) pair must show up as a flip.
+    assert (0, 1) in result.flipped_pairs
+
+
+def test_decoupling_does_not_fire_on_pure_variance_shift(db: str) -> None:
+    """Per-axis variance shifts (no off-diagonal change) shouldn't fire.
+
+    Both windows have zero correlation; current window has higher
+    variance on each axis (which fragility would catch). Decoupling
+    should stay quiet because off-diagonals stay near zero and the
+    Frobenius delta is dominated by diagonal-only changes — but the
+    `h_decoupling` default still allows it through, so we ALSO pass
+    a high explicit threshold here.
+    """
+    _seed_anchor_baseline("A1", (0.6, 0.6))
+    _seed_correlated_stream(
+        "A1",
+        n_baseline=80,
+        n_current=40,
+        baseline_corr=0.0,
+        current_corr=0.0,
+        seed=42,
+    )
+    result = decoupling_signal(
+        anchor_id="A1",
+        axis_ids=AXIS_IDS,
+        baseline_window=80,
+        current_window=40,
+        # Override threshold to focus on the sign-flip half of the
+        # signal — variance shifts that don't flip the off-diagonal
+        # should not fire.
+        h_decoupling=10.0,
+    )
+    assert result.flipped_pairs == []
+    assert result.signal_fired is False
+
+
+def test_compute_axis_covariance_returns_correct_shape(db: str) -> None:
+    _seed_anchor_baseline("A1", (0.6, 0.6))
+    for i in range(20):
+        # Co-vary axes within [0, 1] so pydantic's aggregate ≤ 1.0
+        # constraint stays satisfied.
+        v = 0.30 + 0.025 * i
+        _seed_perturbation_score("A1", f"p_{i}", (v, v + 0.05))
+    cov = compute_axis_covariance(anchor_id="A1", axis_ids=AXIS_IDS, window=20)
+    assert cov.shape == (2, 2)
+    # Same direction on both axes → strongly positive correlation.
+    assert cov[0, 1] > 0.0
+
+
+def test_decoupling_skips_when_evidence_is_insufficient(db: str) -> None:
+    _seed_anchor_baseline("A1", (0.6, 0.6))
+    # Only 4 perturbation samples — far below the requested current_window=30.
+    for i in range(4):
+        _seed_perturbation_score("A1", f"few_{i}", (0.5, 0.5))
+    result = decoupling_signal(
+        anchor_id="A1",
+        axis_ids=AXIS_IDS,
+        baseline_window=60,
+        current_window=30,
+    )
+    assert result.signal_fired is False
+
+
+# ---------------------------------------------------------------------------
+# §4.6 Example 4: positional drift = 0, fragility = 0, covariance flips
+# ---------------------------------------------------------------------------
+
+
+def test_example4_only_decoupling_fires_on_pure_covariance_flip(db: str) -> None:
+    """Same per-axis means, same per-axis variance, opposite correlation.
+
+    `decoupling` should fire while a per-axis fragility comparison
+    (which compares means and variances independently) would not.
+    """
+    _seed_anchor_baseline("A1", (0.6, 0.6))
+    _seed_correlated_stream(
+        "A1",
+        n_baseline=80,
+        n_current=40,
+        baseline_corr=+0.85,
+        current_corr=-0.85,
+        seed=7,
+    )
+    result = decoupling_signal(
+        anchor_id="A1",
+        axis_ids=AXIS_IDS,
+        baseline_window=80,
+        current_window=40,
+    )
+    assert result.signal_fired is True
+    # Sanity: per-axis means are roughly the same → positional drift ≈ 0.
+    base_mean = result.baseline_cov.diagonal().mean()
+    cur_mean = result.current_cov.diagonal().mean()
+    # Both windows draw from the same distribution shape; per-axis
+    # variance hasn't shifted by more than ~30%.
+    assert abs(cur_mean - base_mean) < 0.4 * max(base_mean, 1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Storage round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_query_structural_signal(db: str) -> None:
+    sid = record_structural_signal(
+        anchor_id="A1",
+        signal_type="decoupling",
+        metric_value=0.42,
+        threshold=0.20,
+        evidence={"flipped_pairs": [[0, 1]], "frobenius_delta": 0.42},
+    )
+    assert sid >= 1
+    by_anchor = signals_for_anchor("A1")
+    assert len(by_anchor) == 1
+    row = by_anchor[0]
+    assert row["signal_type"] == "decoupling"
+    assert row["metric_value"] == pytest.approx(0.42)
+    assert row["threshold"] == pytest.approx(0.20)
+    assert row["evidence"]["flipped_pairs"] == [[0, 1]]
+    listed = list_structural_signals()
+    assert len(listed) == 1
+
+
+def test_record_structural_signal_rejects_unknown_type(db: str) -> None:
+    with pytest.raises(ValueError, match="unknown signal_type"):
+        record_structural_signal(
+            anchor_id="A1",
+            signal_type="bogus",
+            metric_value=0.1,
+            threshold=0.2,
+        )

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,0 +1,483 @@
+"""Tests for the Phase 5 Riemannian metric learner (issue #50).
+
+Covers:
+- Synthetic Jacobian field reconstruction (analytic g(c)).
+- §4.6 Example 1 (interior vs near-boundary risk amplification).
+- §4.6 Example 3 (drift trajectory with growing Riemannian/Euclidean ratio).
+- Positive-definiteness invariant for random points.
+- Persistence round-trip (.npz save/load).
+- CLI smoke (`fit-metric`, `metric-distance`).
+- Localizer integration (Riemannian distance via `metric=` kwarg).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from alembic import command
+from alembic.config import Config
+from typer.testing import CliRunner
+
+from maimonedes.cli import app
+from maimonedes.core.compliance import ComplianceScore
+from maimonedes.core.perturbation import PerturbationProbe
+from maimonedes.monitor.metric import (
+    MetricMLP,
+    RiemannianMetric,
+    _build_lower_triangular,
+    _build_lower_triangular_grad,
+    _frobenius_loss_and_grad,
+    euclidean_distance,
+    fit_metric,
+    fit_metric_from_pairs,
+    metric_at,
+    riemannian_distance,
+)
+from maimonedes.monitor.localizer import boundary_distance
+from maimonedes.settings import Settings
+from maimonedes.storage.compliance import record_score
+from maimonedes.storage.perturbations import record_perturbation
+from maimonedes.storage.metric_fits import (
+    latest_metric_fit_for_policy,
+    list_metric_fits,
+)
+from maimonedes.storage.repo import init_engine, reset_engine_for_tests
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ALEMBIC_INI = PROJECT_ROOT / "alembic.ini"
+
+runner = CliRunner()
+
+
+def _alembic_cfg(database_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.set_main_option("script_location", str(PROJECT_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    db_path = tmp_path / "metric.sqlite"
+    url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    reset_engine_for_tests()
+    init_engine(Settings(database_url=url))
+    command.upgrade(_alembic_cfg(url), "head")
+    yield url
+    reset_engine_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy primitives
+# ---------------------------------------------------------------------------
+
+
+def test_lower_triangular_construction_is_positive_definite() -> None:
+    rng = np.random.default_rng(0)
+    k = 3
+    for _ in range(50):
+        params = rng.standard_normal(k * (k + 1) // 2)
+        L = _build_lower_triangular(params, k)
+        # Strictly lower-triangular layout (diagonal is exp() so > 0).
+        for i in range(k):
+            for j in range(i + 1, k):
+                assert L[i, j] == 0.0
+            assert L[i, i] > 0.0
+        g = L @ L.T
+        eigvals = np.linalg.eigvalsh(g)
+        assert eigvals.min() > 0.0
+
+
+def test_backprop_matches_finite_difference() -> None:
+    """Gradient check: analytic ≈ finite-difference for hidden + output layers."""
+    mlp = MetricMLP.init(k=3, hidden=8, depth=2, seed=42)
+    c = np.array([0.5, 0.7, 0.3])
+    g_target = np.array(
+        [[2.0, 0.3, 0.0], [0.3, 1.0, 0.1], [0.0, 0.1, 0.5]]
+    )
+
+    params, acts = mlp.forward(c)
+    L = _build_lower_triangular(params, 3)
+    _, dL = _frobenius_loss_and_grad(L, g_target)
+    grad_params = _build_lower_triangular_grad(dL, params, 3)
+    grads = mlp.backward(acts, grad_params)
+
+    eps = 1e-6
+
+    def loss_fn() -> float:
+        p, _ = mlp.forward(c)
+        L_local = _build_lower_triangular(p, 3)
+        loss, _ = _frobenius_loss_and_grad(L_local, g_target)
+        return loss
+
+    for layer_idx in range(len(mlp.weights)):
+        W, b = mlp.weights[layer_idx]
+        # Spot-check a few weight entries per layer.
+        for (i, j) in [(0, 0), (W.shape[0] - 1, W.shape[1] - 1)]:
+            original = W[i, j]
+            W[i, j] = original + eps
+            l_plus = loss_fn()
+            W[i, j] = original - eps
+            l_minus = loss_fn()
+            W[i, j] = original
+            fd = (l_plus - l_minus) / (2 * eps)
+            analytic = grads[layer_idx][0][i, j]
+            if abs(fd) + abs(analytic) > 1e-9:
+                assert abs(fd - analytic) < max(1e-3 * abs(fd), 1e-5), (
+                    f"layer {layer_idx} W[{i},{j}]: fd={fd} analytic={analytic}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: synthetic Jacobian field reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_fit_reconstructs_diagonal_metric_field() -> None:
+    """Anisotropic diagonal field: eigenvalue grows with `1 - c0`.
+
+    The MLP should learn g(c) ≈ diag(1 + 5(1 - c0), 1) within a small
+    tolerance at unseen points.
+    """
+    rng = np.random.default_rng(0)
+    n_samples = 120
+    k = 2
+    c_array = rng.uniform(0.0, 1.0, size=(n_samples, k))
+    g_array = np.zeros((n_samples, k, k))
+    for i in range(n_samples):
+        eig = 1.0 + 5.0 * (1.0 - c_array[i, 0])
+        g_array[i] = np.diag([eig, 1.0])
+
+    metric = fit_metric_from_pairs(
+        c_array,
+        g_array,
+        k=k,
+        hidden=24,
+        depth=2,
+        epochs=400,
+        lr=0.02,
+        seed=0,
+        policy_id="synth",
+    )
+
+    for c_test, eig_true in [
+        (np.array([0.1, 0.5]), 1.0 + 5.0 * 0.9),
+        (np.array([0.5, 0.5]), 1.0 + 5.0 * 0.5),
+        (np.array([0.9, 0.5]), 1.0 + 5.0 * 0.1),
+    ]:
+        g_pred = metric_at(metric, c_test)
+        assert g_pred[0, 0] == pytest.approx(eig_true, abs=0.4)
+        assert g_pred[1, 1] == pytest.approx(1.0, abs=0.3)
+
+
+def test_metric_at_is_positive_definite_on_random_points() -> None:
+    """1000 random `c` samples → all eigenvalues of `metric_at(c)` > 0."""
+    rng = np.random.default_rng(3)
+    c_array = rng.uniform(-1.0, 2.0, size=(40, 2))
+    g_array = np.tile(np.eye(2)[None, :, :], (40, 1, 1))
+    metric = fit_metric_from_pairs(
+        c_array,
+        g_array,
+        k=2,
+        hidden=12,
+        depth=2,
+        epochs=80,
+        lr=0.02,
+        seed=1,
+        policy_id="pd",
+    )
+    test_points = rng.uniform(-1.5, 2.5, size=(1000, 2))
+    for c in test_points:
+        g = metric_at(metric, c)
+        eigvals = np.linalg.eigvalsh(g)
+        assert eigvals.min() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# §4.6 Example 1: interior vs near-boundary
+# ---------------------------------------------------------------------------
+
+
+def _make_radial_metric(k: int = 2) -> RiemannianMetric:
+    """Synthesise the §4.6 boundary geometry directly.
+
+    Avoids re-fitting an MLP for every test by constructing a
+    `RiemannianMetric` whose forward pass evaluates an analytic
+    radial field. The resulting metric is identity in the safe
+    interior (sum > 1.50) and grows quadratically as the system
+    approaches the boundary line `c0 + c1 = 1.10`.
+    """
+    rng = np.random.default_rng(7)
+    boundary_offset = 1.10
+    n = 240
+    c_arr = rng.uniform(0.3, 1.0, size=(n, k))
+    g_arr = np.zeros((n, k, k))
+    for i in range(n):
+        d_b = c_arr[i].sum() - boundary_offset
+        # Scale: 1 in the safe interior (d_b >= 0.4); rises sharply
+        # as d_b shrinks toward the boundary.
+        if d_b >= 0.4:
+            scale = 1.0
+        else:
+            scale = max(1.0, (0.4 / max(d_b, 0.05)) ** 2)
+        g_arr[i] = np.eye(k) * scale
+    return fit_metric_from_pairs(
+        c_arr,
+        g_arr,
+        k=k,
+        hidden=24,
+        depth=2,
+        epochs=800,
+        lr=0.02,
+        seed=0,
+        policy_id="example1",
+    )
+
+
+def test_example1_interior_riemannian_is_smaller_than_boundary() -> None:
+    """System A (deep interior) → Riemannian < Euclidean.
+
+    System B (near boundary) → Riemannian ≫ Euclidean.
+    """
+    metric = _make_radial_metric()
+    # System A: starts at (0.91, 0.88), moves to (0.82, 0.79). Sum stays > 1.6.
+    a0, a1 = np.array([0.91, 0.88]), np.array([0.82, 0.79])
+    # System B: starts at (0.64, 0.61), moves to (0.55, 0.52). Sum drops near boundary.
+    b0, b1 = np.array([0.64, 0.61]), np.array([0.55, 0.52])
+
+    eucl_a = euclidean_distance(a0, a1)
+    eucl_b = euclidean_distance(b0, b1)
+    riem_a = riemannian_distance(metric, a0, a1)
+    riem_b = riemannian_distance(metric, b0, b1)
+
+    # Same Euclidean displacement (≈ 0.127), wildly different risk.
+    assert eucl_a == pytest.approx(eucl_b, abs=1e-3)
+    # System A is interior: Riemannian on the order of Euclidean.
+    assert riem_a < 1.5 * eucl_a
+    # System B is near-boundary: Riemannian dwarfs Euclidean.
+    assert riem_b > 3.0 * eucl_b
+
+
+# ---------------------------------------------------------------------------
+# §4.6 Example 3: temporal drift trajectory amplification
+# ---------------------------------------------------------------------------
+
+
+def test_example3_riemannian_amplifies_in_dangerous_region() -> None:
+    """t₀→t₁ Riemannian/Euclidean ≈ 1.x; t₀→t₂ ratio is materially larger."""
+    metric = _make_radial_metric()
+    t0 = np.array([0.89, 0.85])
+    t1 = np.array([0.81, 0.79])
+    t2 = np.array([0.71, 0.68])
+
+    eucl_01 = euclidean_distance(t0, t1)
+    eucl_02 = euclidean_distance(t0, t2)
+    riem_01 = riemannian_distance(metric, t0, t1)
+    riem_02 = riemannian_distance(metric, t0, t2)
+
+    ratio_01 = riem_01 / eucl_01
+    ratio_02 = riem_02 / eucl_02
+    # t0→t1 stays in the gentle region; ratio close to 1.
+    assert ratio_01 < 2.5
+    # t0→t2 enters the steep region near c1+c2=1.10; ratio amplifies.
+    assert ratio_02 > ratio_01 * 1.5
+    # The §4.6 narrative says t0→t2 Riemannian is much larger absolutely.
+    assert riem_02 > 2.0 * riem_01
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    c_arr = rng.uniform(0.0, 1.0, size=(20, 2))
+    g_arr = np.tile(np.eye(2)[None, :, :], (20, 1, 1))
+    metric = fit_metric_from_pairs(
+        c_arr,
+        g_arr,
+        k=2,
+        hidden=8,
+        depth=2,
+        epochs=20,
+        seed=0,
+        policy_id="rt",
+        sub_condition_ids=("a", "b"),
+    )
+    out = tmp_path / "metric.npz"
+    metric.save(out)
+    assert out.exists()
+
+    loaded = RiemannianMetric.load(out)
+    assert loaded.policy_id == "rt"
+    assert loaded.k == 2
+    assert loaded.sub_condition_ids == ("a", "b")
+    test_c = np.array([0.3, 0.5])
+    g0 = metric_at(metric, test_c)
+    g1 = metric_at(loaded, test_c)
+    np.testing.assert_allclose(g0, g1, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Localizer integration: opt-in metric kwarg changes ranking
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_distance_with_metric_returns_riemannian() -> None:
+    """When `metric` is supplied, `boundary_distance` reports the Riemannian length.
+
+    Using a flat (≈ identity) metric yields a value close to the
+    rubric-weighted Euclidean distance up to scale; using the radial
+    metric near the boundary inflates the value.
+    """
+    flat_metric = fit_metric_from_pairs(
+        np.array([[0.5, 0.5], [0.6, 0.7]]),
+        np.tile(np.eye(2)[None, :, :], (2, 1, 1)),
+        k=2,
+        hidden=4,
+        depth=1,
+        epochs=10,
+        seed=0,
+        policy_id="flat",
+        sub_condition_ids=("a", "b"),
+    )
+    radial = _make_radial_metric()
+
+    score = ComplianceScore(
+        anchor_id="A1",
+        policy_id="x",
+        per_sub_condition={"a": 0.30, "b": 0.30},
+        aggregate=0.30,
+        judge_model="judge:test",
+        supervised_model="supervised:test",
+        probe_role="anchor",
+    )
+    thresholds = {"a": 0.5, "b": 0.5}
+    weights = {"a": 0.5, "b": 0.5}
+
+    eucl = boundary_distance(score, thresholds=thresholds, weights=weights)
+    flat_riem = boundary_distance(
+        score, thresholds=thresholds, weights=weights, metric=flat_metric
+    )
+    # Flat metric ≈ identity → Riemannian length close to Euclidean
+    # (allow generous tolerance because the MLP is tiny / barely fit).
+    assert flat_riem == pytest.approx(eucl, abs=0.5)
+
+    # Radial metric near boundary produces a longer geodesic.
+    radial_riem = boundary_distance(
+        score, thresholds=thresholds, weights=weights, metric=radial
+    )
+    assert radial_riem > eucl
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke: fit-metric + metric-distance round-trip
+# ---------------------------------------------------------------------------
+
+
+SCOPE_SUB_IDS = (
+    "flags_physician_review",
+    "expresses_uncertainty",
+    "avoids_unqualified_prescriptive_language",
+    "recommendation_within_scope",
+    "recommendation_appropriate_specificity",
+)
+
+
+def _seed_anchor_for_metric(anchor_id: str, base: float) -> None:
+    """Seed one anchor + four perturbations against the 5-axis scope rubric.
+
+    Pads the per-axis vector to all five rubric sub-conditions so
+    `_collect_anchor_pairs` accepts the row.
+    """
+    def _score(values: list[float], probe_role: str, perturbation_id: int | None = None) -> ComplianceScore:
+        return ComplianceScore(
+            anchor_id=anchor_id,
+            policy_id="scope_of_practice",
+            per_sub_condition={s: v for s, v in zip(SCOPE_SUB_IDS, values)},
+            aggregate=float(sum(values) / len(values)),
+            judge_model="judge:test",
+            supervised_model="supervised:test",
+            perturbation_id=perturbation_id,
+            probe_role=probe_role,
+        )
+
+    record_score(_score([base] * 5, probe_role="anchor"))
+    perturbation_specs = [
+        ("authority:gp", "authority", [-0.15, 0.0, -0.05, 0.0, 0.0]),
+        ("boundary:should", "boundary", [0.0, -0.20, 0.0, -0.05, 0.0]),
+        ("demographic:elder", "demographic", [-0.05, -0.05, -0.05, 0.0, -0.10]),
+        ("paraphrase:1", "paraphrase", [-0.10, -0.05, 0.0, -0.05, -0.05]),
+    ]
+    for label, kind, deltas in perturbation_specs:
+        probe = PerturbationProbe(
+            anchor_id=anchor_id,
+            scenario=f"perturbed by {label}",
+            perturbation_kind=kind,  # type: ignore[arg-type]
+            transform_label=label,
+        )
+        row_id = record_perturbation(probe)
+        values = [max(0.0, base + d) for d in deltas]
+        record_score(_score(values, probe_role="perturbation", perturbation_id=row_id))
+
+
+def test_cli_fit_and_distance_roundtrip(db: str, tmp_path: Path) -> None:
+    """`maimonedes fit-metric` persists; `maimonedes metric-distance` reads."""
+    # Two anchors with usable Jacobians.
+    _seed_anchor_for_metric("A1", base=0.85)
+    _seed_anchor_for_metric("A2", base=0.60)
+
+    out_dir = tmp_path / "models"
+    result = runner.invoke(
+        app,
+        [
+            "fit-metric",
+            "--epochs",
+            "30",
+            "--hidden",
+            "8",
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+    if result.exit_code != 0:
+        print("OUTPUT:", result.output)
+        if result.exception is not None:
+            import traceback
+            traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+    assert result.exit_code == 0, result.output
+    assert "metric_fit_id=" in result.output
+    fits = list_metric_fits()
+    assert len(fits) == 1
+    npz_path = Path(str(fits[0]["path"]))
+    assert npz_path.exists()
+
+    # metric-distance: pick two 5-axis compliance points and check both
+    # numbers print. The 5-axis layout matches the seeded anchors above.
+    c0 = "0.85,0.80,0.85,0.80,0.85"
+    c1 = "0.55,0.50,0.55,0.50,0.55"
+    dist_result = runner.invoke(app, ["metric-distance", c0, c1])
+    assert dist_result.exit_code == 0, dist_result.output
+    assert "euclidean_distance" in dist_result.output
+    assert "riemannian_distance" in dist_result.output
+    assert "ratio (riem/eucl)" in dist_result.output
+
+    # latest_metric_fit_for_policy resolves the same row.
+    latest = latest_metric_fit_for_policy("scope_of_practice")
+    assert latest is not None
+    assert latest["id"] == fits[0]["id"]
+
+
+def test_fit_metric_errors_when_no_anchors_exist(db: str, tmp_path: Path) -> None:
+    out_dir = tmp_path / "models"
+    result = runner.invoke(
+        app,
+        ["fit-metric", "--epochs", "5", "--output-dir", str(out_dir)],
+    )
+    # No anchors seeded → fit raises ValueError → CLI exits 2.
+    assert result.exit_code == 2, result.output
+    assert "no anchor Jacobians" in result.output


### PR DESCRIPTION
This pull request introduces Phase 5 features for Riemannian metric learning and structural signal detection, including new Alembic migrations for storing metric fits and fired structural alerts, CLI commands for fitting and comparing metrics, and the implementation of the curvature-based early warning signal. The changes improve the system’s ability to track, store, and analyze learned metrics and structural changes in the compliance landscape.

**Database migrations:**

* Added `0008_metric_fits` migration to create the `metric_fits` table, storing trained Riemannian metrics with provenance and artefact paths.
* Added `0009_structural_signals` migration to create the `structural_signals` table, recording fired decoupling and curvature alerts with evidence blobs.

**CLI and reporting enhancements:**

* Added `fit-metric` and `metric-distance` commands to the CLI for fitting Riemannian metrics, persisting them, and comparing Euclidean vs. Riemannian distances between compliance points.
* Updated `drift-report` to support an optional `--metric` argument, displaying Euclidean and Riemannian displacements per anchor when a metric is specified. [[1]](diffhunk://#diff-291c358d299476dae6dddb0cbe0c4afba357379a6b1005cc29692a8fa04280c6R811-R816) [[2]](diffhunk://#diff-291c358d299476dae6dddb0cbe0c4afba357379a6b1005cc29692a8fa04280c6L690-R708) [[3]](diffhunk://#diff-291c358d299476dae6dddb0cbe0c4afba357379a6b1005cc29692a8fa04280c6L700-R722) [[4]](diffhunk://#diff-291c358d299476dae6dddb0cbe0c4afba357379a6b1005cc29692a8fa04280c6L735-R757) [[5]](diffhunk://#diff-291c358d299476dae6dddb0cbe0c4afba357379a6b1005cc29692a8fa04280c6R767-R779)

**Structural signal detection:**

* Implemented the curvature signal in `monitor/curvature.py`, detecting when the local metric’s condition number increases significantly at an anchor, signaling geometric reorganization.