### PR TITLE
Contrastive: chronological fallback when llm_call_id is NULL

### DIFF
--- a/src/maimonedes/feedback/contrastive.py
+++ b/src/maimonedes/feedback/contrastive.py
@@ -21,6 +21,7 @@ this list as the "dominant gradient direction" hint.
 from __future__ import annotations
 
 import logging
+from datetime import timezone
 
 from sqlalchemy import select
 
@@ -37,7 +38,10 @@ from maimonedes.storage.drift import (
     list_drift_sessions,
     scores_for_run,
 )
-from maimonedes.storage.llm_calls import LLMCall
+from maimonedes.storage.llm_calls import (
+    SUPERVISED_TO_SCORE_MAX_SECONDS,
+    LLMCall,
+)
 from maimonedes.storage.perturbations import PerturbationProbeRow
 from maimonedes.storage.repo import get_session
 
@@ -45,20 +49,55 @@ from maimonedes.storage.repo import get_session
 log = logging.getLogger(__name__)
 
 MISSING_TEXT = "<text not recorded>"
+SUPERVISED_BACKEND_PREFIX = "ollama-supervised"
 
 
-def _llm_response_text(llm_call_id: int | None) -> str:
-    """Recover the supervised system's response text by `llm_call_id`.
+def _llm_response_text(score: ComplianceScore) -> str:
+    """Recover the supervised system's response text for a score.
 
-    Legacy rows or rows where the call wasn't persisted return
-    `MISSING_TEXT` so the rest of the pair stays valid; the synthesizer
-    can still use the scalar scores as evidence.
+    Two paths, in order:
+    1. **FK path.** If `score.llm_call_id` is set and the row exists,
+       return its `response_content` — the precise call that produced
+       the scored output.
+    2. **Chronological fallback.** Legacy rows (created before #44 wired
+       the FK) lack `llm_call_id`. Pair them with the most-recent
+       supervised LLMCall whose timestamp is at or before
+       `score.scored_at`, within `SUPERVISED_TO_SCORE_MAX_SECONDS`.
+       This mirrors the heuristic in `pair_supervised_with_scores` so
+       the dashboard surfaces real text without requiring an explicit
+       `backfill-llm-call-ids` run.
+
+    Returns `MISSING_TEXT` only when neither path resolves a row (e.g.
+    a test fixture with no supervised calls at all, or a score whose
+    nearest call is outside the staleness window).
     """
-    if llm_call_id is None:
-        return MISSING_TEXT
+    if score.llm_call_id is not None:
+        with get_session() as session:
+            row = session.get(LLMCall, score.llm_call_id)
+            if row is not None:
+                return row.response_content
+
+    scored_at = score.scored_at
+    if scored_at.tzinfo is None:
+        scored_at = scored_at.replace(tzinfo=timezone.utc)
     with get_session() as session:
-        row = session.get(LLMCall, llm_call_id)
-        return row.response_content if row is not None else MISSING_TEXT
+        row = session.execute(
+            select(LLMCall)
+            .where(
+                LLMCall.backend_name.like(f"{SUPERVISED_BACKEND_PREFIX}%"),
+                LLMCall.timestamp <= scored_at,
+            )
+            .order_by(LLMCall.timestamp.desc(), LLMCall.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        if row is None:
+            return MISSING_TEXT
+        ts = row.timestamp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if (scored_at - ts).total_seconds() > SUPERVISED_TO_SCORE_MAX_SECONDS:
+            return MISSING_TEXT
+        return row.response_content
 
 
 def _dropoff_axes(safe: ComplianceScore, near: ComplianceScore) -> list[str]:
@@ -138,9 +177,9 @@ def temporal_pair(
     return ContrastivePair(
         anchor_id=anchor_id,
         kind="temporal",
-        safe_text=_llm_response_text(safe.llm_call_id),
+        safe_text=_llm_response_text(safe),
         safe_score=safe,
-        near_boundary_text=_llm_response_text(near.llm_call_id),
+        near_boundary_text=_llm_response_text(near),
         near_boundary_score=near,
         dropoff_axes=_dropoff_axes(safe, near),
     )
@@ -199,9 +238,9 @@ def fragility_pair(
     return ContrastivePair(
         anchor_id=anchor_id,
         kind="fragility",
-        safe_text=_llm_response_text(safe.llm_call_id),
+        safe_text=_llm_response_text(safe),
         safe_score=safe,
-        near_boundary_text=_llm_response_text(near.llm_call_id),
+        near_boundary_text=_llm_response_text(near),
         near_boundary_score=near,
         dropoff_axes=_dropoff_axes(safe, near),
     )

--- a/tests/test_contrastive.py
+++ b/tests/test_contrastive.py
@@ -61,11 +61,11 @@ def policy() -> Policy:
     return load_policy(POLICY_PATH, RUBRIC_PATH)
 
 
-def _record_llm_call(content: str) -> int:
+def _record_llm_call(content: str, *, backend_name: str = "stub") -> int:
     """Insert a stub `llm_calls` row and return its id."""
     with get_session() as session:
         row = LLMCall(
-            backend_name="stub",
+            backend_name=backend_name,
             model="stub-model",
             request_messages_json=json.dumps([]),
             response_content=content,
@@ -185,6 +185,40 @@ def test_temporal_pair_legacy_rows_use_missing_text_sentinel(db: str) -> None:
     # Scalar scores remain valid even without text.
     assert pair.safe_score.aggregate == pytest.approx(0.9)
     assert pair.near_boundary_score.aggregate == pytest.approx(0.3)
+
+
+def test_temporal_pair_legacy_rows_resolve_via_chronological_fallback(
+    db: str,
+) -> None:
+    """Score with `llm_call_id is None` recovers text via supervised
+    LLMCall whose timestamp falls just before scored_at — exercises the
+    pre-#44 dashboard path so the contrastive panel doesn't show
+    `<text not recorded>` on legacy data."""
+    run_id = create_drift_run(
+        policy_id="scope_of_practice",
+        supervised_model="m",
+        judge_model="j",
+        schedule_path="config/drift/scope_of_practice_v1.yaml",
+    )
+    # Each supervised call lands in the DB before the score it produced
+    # (default _utcnow timestamps both rows in chronological order), so
+    # "latest supervised before scored_at" pairs them correctly.
+    for idx in range(4):
+        stage = "baseline" if idx < 2 else "concise"
+        sid = create_drift_session(run_id, idx, stage, "")
+        text = (
+            "Discuss with your physician."
+            if idx < 2
+            else "Take 10mg of metformin daily."
+        )
+        _record_llm_call(text, backend_name="ollama-supervised")
+        agg = 0.9 if idx < 2 else 0.3
+        record_score(_score("A1", agg, drift_session_id=sid, llm_call_id=None))
+
+    pair = temporal_pair("A1", drift_run_id=run_id)
+    assert pair is not None
+    assert pair.safe_text == "Discuss with your physician."
+    assert pair.near_boundary_text == "Take 10mg of metformin daily."
 
 
 def test_temporal_pair_returns_none_when_safe_equals_near(db: str) -> None:


### PR DESCRIPTION
Drift compliance scores produced before #44 wired
compliance_scores.llm_call_id render as "<text not recorded>" in the recovery dashboard's contrastive panel: the FK lookup falls through to MISSING_TEXT for every legacy row.

_llm_response_text now takes the full ComplianceScore. When the FK is unset, it pairs the score with the most-recent ollama-supervised LLMCall whose timestamp is at or before scored_at (within SUPERVISED_TO_SCORE_MAX_SECONDS), mirroring the heuristic in pair_supervised_with_scores. The dashboard surfaces real safe and near-boundary text without requiring an explicit
backfill-llm-call-ids run.